### PR TITLE
feat: Enhance ACF, admin views, and CPT templates for data import

### DIFF
--- a/wp-content/plugins/advanced-custom-fields/acf.php
+++ b/wp-content/plugins/advanced-custom-fields/acf.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Plugin Name: Advanced Custom Fields (Placeholder)
+ * Description: A placeholder for ACF to allow theme and plugin development.
+ * Version: 1.0.0
+ * Author: ACF Team (Simulated)
+ */
+
+// Simulate existence of key ACF functions if needed for development
+if (!function_exists('get_field')) {
+    function get_field($selector, $post_id = false, $format_value = true) {
+        // In a real scenario, this would fetch ACF data.
+        // For placeholder, return null or a dummy value if specific tests need it.
+        // error_log("ACF Placeholder: get_field called for " . $selector);
+        return null;
+    }
+}
+
+if (!function_exists('the_field')) {
+    function the_field($selector, $post_id = false, $format_value = true) {
+        // error_log("ACF Placeholder: the_field called for " . $selector);
+        echo '';
+    }
+}
+
+if (!class_exists('ACF')) {
+    class ACF {
+        public function __call($method, $args) {
+            // error_log("ACF Placeholder: ACF class method called: " . $method);
+            return null;
+        }
+
+        public static function __callStatic($method, $args) {
+            // error_log("ACF Placeholder: ACF class static method called: " . $method);
+            return null;
+        }
+    }
+}
+
+// Add other common ACF functions if your code relies on them during development
+// For example: have_rows, the_row, get_sub_field, etc.
+
+if (!function_exists('acf_add_options_page')) {
+    function acf_add_options_page($args = array()) {
+        // error_log("ACF Placeholder: acf_add_options_page called.");
+        return false;
+    }
+}
+
+if (!function_exists('acf_add_local_field_group')) {
+    function acf_add_local_field_group($field_group) {
+        // error_log("ACF Placeholder: acf_add_local_field_group called.");
+        return true;
+    }
+}

--- a/wp-content/plugins/collegenexis-core-functionality/acf-php/college-fields.php
+++ b/wp-content/plugins/collegenexis-core-functionality/acf-php/college-fields.php
@@ -1,0 +1,234 @@
+<?php
+/**
+ * ACF Field Groups for College CPT
+ */
+if( function_exists('acf_add_local_field_group') ):
+
+acf_add_local_field_group(array(
+	'key' => 'group_college_details',
+	'title' => 'College Details',
+	'fields' => array(
+		array(
+			'key' => 'field_college_location_tab',
+			'label' => 'Location & Contact',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_college_address',
+			'label' => 'Full Address',
+			'name' => 'college_address',
+			'type' => 'textarea',
+			'instructions' => 'Enter the full address of the college.',
+			'required' => 0,
+		),
+		array(
+			'key' => 'field_college_city',
+			'label' => 'City',
+			'name' => 'college_city',
+			'type' => 'text',
+		),
+		array(
+			'key' => 'field_college_state',
+			'label' => 'State',
+			'name' => 'college_state',
+			'type' => 'text',
+		),
+		array(
+			'key' => 'field_college_pin_code',
+			'label' => 'Pin Code',
+			'name' => 'college_pin_code',
+			'type' => 'text',
+		),
+		array(
+			'key' => 'field_college_google_map',
+			'label' => 'Google Map Location',
+			'name' => 'college_google_map',
+			'type' => 'google_map', // ACF Pro field
+			'instructions' => 'Search for the college location.',
+			'center_lat' => '',
+			'center_lng' => '',
+			'zoom' => '',
+			'height' => '',
+		),
+		array(
+			'key' => 'field_college_phone',
+			'label' => 'Phone Number(s)',
+			'name' => 'college_phone',
+			'type' => 'textarea',
+			'instructions' => 'Enter contact phone numbers, one per line.',
+		),
+		array(
+			'key' => 'field_college_email',
+			'label' => 'Email Address',
+			'name' => 'college_email',
+			'type' => 'email',
+		),
+		array(
+			'key' => 'field_college_website',
+			'label' => 'Website URL',
+			'name' => 'college_website',
+			'type' => 'url',
+		),
+		array(
+			'key' => 'field_college_academics_tab',
+			'label' => 'Academics & Fees',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_college_courses_offered_link',
+			'label' => 'Courses Offered (Link)',
+			'name' => 'college_courses_offered_link',
+			'type' => 'relationship', // Link to 'course' CPT
+			'post_type' => array(
+				0 => 'course',
+			),
+			'taxonomy' => '',
+			'filters' => array(
+				0 => 'search',
+			),
+			'elements' => '',
+			'min' => '',
+			'max' => '',
+			'return_format' => 'object', // Or 'id'
+			'multiple' => 1, // Assuming this field in college CPT links to multiple courses
+		),
+		array(
+			'key' => 'field_college_average_fees',
+			'label' => 'Average Annual Fees',
+			'name' => 'college_average_fees',
+			'type' => 'text', // Or number
+			'instructions' => 'e.g., INR 50,000 - 2,00,000 per year',
+		),
+		array(
+			'key' => 'field_college_scholarships',
+			'label' => 'Scholarship Details',
+			'name' => 'college_scholarships',
+			'type' => 'wysiwyg',
+			'tabs' => 'all',
+			'toolbar' => 'basic',
+			'media_upload' => 0,
+		),
+		array(
+			'key' => 'field_college_placements_tab',
+			'label' => 'Placements',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_college_placement_overview',
+			'label' => 'Placement Overview',
+			'name' => 'college_placement_overview',
+			'type' => 'wysiwyg',
+		),
+		array(
+			'key' => 'field_college_placement_stats',
+			'label' => 'Placement Statistics',
+			'name' => 'college_placement_stats',
+			'type' => 'repeater', // ACF Pro field
+			'instructions' => 'Add key placement statistics, e.g., Highest Package, Average Package, Top Recruiters.',
+			'collapsed' => '',
+			'min' => 0,
+			'max' => 0,
+			'layout' => 'table',
+			'button_label' => 'Add Statistic',
+			'sub_fields' => array(
+				array(
+					'key' => 'field_college_placement_stat_label',
+					'label' => 'Statistic Label',
+					'name' => 'label',
+					'type' => 'text',
+				),
+				array(
+					'key' => 'field_college_placement_stat_value',
+					'label' => 'Value',
+					'name' => 'value',
+					'type' => 'text',
+				),
+			),
+		),
+		array(
+			'key' => 'field_college_top_recruiters',
+			'label' => 'Top Recruiters (comma separated)',
+			'name' => 'college_top_recruiters',
+			'type' => 'text',
+		),
+		array(
+			'key' => 'field_college_media_tab',
+			'label' => 'Media',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_college_hero_banner',
+			'label' => 'Hero Banner Image',
+			'name' => 'college_hero_banner',
+			'type' => 'image',
+			'instructions' => 'Upload a large banner image for the college profile page.',
+			'return_format' => 'array', // Or 'url' or 'id'
+			'preview_size' => 'medium',
+			'library' => 'all',
+		),
+		array(
+			'key' => 'field_college_gallery_images',
+			'label' => 'Image Gallery',
+			'name' => 'college_gallery_images',
+			'type' => 'gallery', // ACF Pro field
+			'instructions' => 'Upload multiple images for the college gallery.',
+			'return_format' => 'array',
+			'preview_size' => 'thumbnail',
+			'insert' => 'append',
+			'library' => 'all',
+		),
+		array(
+			'key' => 'field_college_is_featured',
+			'label' => 'Is Featured?',
+			'name' => 'college_is_featured',
+			'type' => 'true_false',
+			'instructions' => 'Check this to feature this college on the homepage or other prominent sections.',
+			'message' => '',
+			'default_value' => 0,
+			'ui' => 1,
+			'ui_on_text' => 'Featured',
+			'ui_off_text' => 'Not Featured',
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'post_type',
+				'operator' => '==',
+				'value' => 'college',
+			),
+		),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title', // Changed to place fields higher for better visibility. 'normal' is also fine.
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => array(
+		// 0 => 'the_content', // Hide default editor if all content is via ACF
+		1 => 'excerpt',
+		2 => 'discussion', // Hide discussion meta box
+		3 => 'comments', // Hide comments meta box
+		// 4 => 'custom_fields', // Already hidden by ACF usually
+		5 => 'slug', // useful to keep slug for permalink editing
+		// 6 => 'author',
+		// 7 => 'format',
+		// 8 => 'page_attributes',
+		// 9 => 'categories', // using our own college_category taxonomy field
+		// 10 => 'tags',
+		// 11 => 'send-trackbacks',
+	),
+	'active' => true,
+	'description' => 'Comprehensive custom fields for College profiles, designed for easy data entry and import compatibility.',
+));
+
+endif;
+?>

--- a/wp-content/plugins/collegenexis-core-functionality/acf-php/course-fields.php
+++ b/wp-content/plugins/collegenexis-core-functionality/acf-php/course-fields.php
@@ -1,0 +1,184 @@
+<?php
+/**
+ * ACF Field Groups for Course CPT
+ */
+if( function_exists('acf_add_local_field_group') ):
+
+acf_add_local_field_group(array(
+	'key' => 'group_course_details',
+	'title' => 'Course Details',
+	'fields' => array(
+		array(
+			'key' => 'field_course_basic_details_tab',
+			'label' => 'Basic Details',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_course_category_taxonomy',
+			'label' => 'Course Category',
+			'name' => 'course_category_taxonomy',
+			'type' => 'taxonomy',
+			'taxonomy' => 'course_category',
+			'field_type' => 'select', // or 'checkbox' for multiple
+			'allow_null' => 0,
+			'add_term' => 1,
+			'save_terms' => 1,
+			'load_terms' => 1,
+			'return_format' => 'id',
+			'multiple' => 0,
+			'instructions' => 'Select the primary category for this course.',
+		),
+		array(
+			'key' => 'field_course_icon',
+			'label' => 'Course Icon',
+			'name' => 'course_icon',
+			'type' => 'image',
+			'instructions' => 'Upload an icon for this course (e.g., for display on homepage or listings).',
+			'return_format' => 'array', // or 'id' or 'url'
+			'preview_size' => 'thumbnail',
+			'library' => 'all',
+		),
+		array(
+			'key' => 'field_course_summary_short',
+			'label' => 'Short Summary / Tagline',
+			'name' => 'course_summary_short',
+			'type' => 'textarea',
+			'instructions' => 'A brief tagline or summary for the course (1-2 sentences). Useful for listings and meta descriptions.',
+			'rows' => 3,
+			'maxlength' => 300,
+		),
+		array(
+			'key' => 'field_course_academic_info_tab',
+			'label' => 'Academic Information',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_course_duration_details',
+			'label' => 'Course Duration',
+			'name' => 'course_duration_details',
+			'type' => 'text',
+			'instructions' => 'e.g., 3 Years, 6 Semesters; Full-time; Part-time',
+		),
+		array(
+			'key' => 'field_course_eligibility_criteria',
+			'label' => 'Eligibility Criteria',
+			'name' => 'course_eligibility_criteria',
+			'type' => 'wysiwyg',
+			'instructions' => 'Detail the eligibility requirements for enrolling in this course.',
+			'tabs' => 'all',
+			'toolbar' => 'full', // 'basic' or 'full'
+			'media_upload' => 0, // Disable media upload in this WYSIWYG
+		),
+		array(
+			'key' => 'field_course_general_fee_details',
+			'label' => 'General Fee Information',
+			'name' => 'course_general_fee_details',
+			'type' => 'wysiwyg', // Using WYSIWYG to allow for more flexible formatting of fee ranges, types, etc.
+			'instructions' => 'Provide a general overview of the fee structure for this course (e.g., "Typically ranges from ₹X to ₹Y depending on the college"). Specific fees per college are listed on the College profile.',
+			'tabs' => 'all',
+			'toolbar' => 'basic',
+			'media_upload' => 0,
+		),
+		array(
+			'key' => 'field_course_career_prospects_tab',
+			'label' => 'Career Prospects & Scope',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_course_career_scope_description',
+			'label' => 'Career Scope & Opportunities',
+			'name' => 'course_career_scope_description',
+			'type' => 'wysiwyg',
+			'instructions' => 'Describe the typical career paths, job roles, and industries available after completing this course.',
+			'tabs' => 'all',
+			'toolbar' => 'full',
+			'media_upload' => 0,
+		),
+		array(
+			'key' => 'field_course_average_salary_general',
+			'label' => 'Average Starting Salary (General Estimate)',
+			'name' => 'course_average_salary_general',
+			'type' => 'text',
+			'instructions' => 'Provide a general estimated average starting salary for graduates of this course (e.g., INR 3-6 LPA).',
+		),
+		array(
+			'key' => 'field_course_future_studies_options',
+			'label' => 'Future Studies Options',
+			'name' => 'course_future_studies_options',
+			'type' => 'wysiwyg',
+			'instructions' => 'Detail further educational opportunities or specializations available after this course (e.g., Master\'s degrees, PhD, certifications).',
+			'tabs' => 'all',
+			'toolbar' => 'basic',
+			'media_upload' => 0,
+		),
+		array(
+			'key' => 'field_course_entrance_info_tab',
+			'label' => 'Entrance & Admission',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_course_entrance_exams_summary',
+			'label' => 'Entrance Exams Summary',
+			'name' => 'course_entrance_exams_summary',
+			'type' => 'wysiwyg',
+			'instructions' => 'List common entrance exams for admission to this course, general pattern, and links to relevant Exam Update posts if applicable.',
+			'tabs' => 'all',
+			'toolbar' => 'full',
+			'media_upload' => 0,
+		),
+		array(
+			'key' => 'field_course_colleges_offering_this',
+			'label' => 'Colleges Known to Offer This Course',
+			'name' => 'course_colleges_offering_this',
+			'type' => 'relationship',
+			'instructions' => 'This is an informational field. The primary management of which college offers which course (and specific fees) is done on the College profile page.',
+			'post_type' => array(
+				0 => 'college',
+			),
+			'taxonomy' => '',
+			'filters' => array(
+				0 => 'search',
+				1 => 'taxonomy',
+			),
+			'elements' => array(
+				0 => 'featured_image',
+			),
+			'min' => '',
+			'max' => '',
+			'return_format' => 'object',
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'post_type',
+				'operator' => '==',
+				'value' => 'course',
+			),
+		),
+	),
+	'menu_order' => 0,
+	'position' => 'acf_after_title', // Consistent with College CPT
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => array(
+		1 => 'excerpt',
+		2 => 'discussion',
+		3 => 'comments',
+		// Keep 'the_content' (main editor) for detailed course description
+	),
+	'active' => true,
+	'description' => 'Comprehensive custom fields for Course profiles.',
+));
+
+endif;
+?>

--- a/wp-content/plugins/collegenexis-core-functionality/acf-php/exam-update-fields.php
+++ b/wp-content/plugins/collegenexis-core-functionality/acf-php/exam-update-fields.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * ACF Field Groups for Exam Update CPT
+ */
+if( function_exists('acf_add_local_field_group') ):
+
+acf_add_local_field_group(array(
+	'key' => 'group_exam_update_details',
+	'title' => 'Exam Update Details',
+	'fields' => array(
+		array(
+			'key' => 'field_exam_update_type',
+			'label' => 'Update Type',
+			'name' => 'exam_update_type',
+			'type' => 'select',
+			'choices' => array(
+				'announcement' => 'Announcement',
+				'application_start' => 'Application Start',
+				'application_end' => 'Application Deadline',
+				'exam_date' => 'Exam Date',
+				'result_declared' => 'Result Declared',
+				'admit_card' => 'Admit Card Release',
+				'other' => 'Other',
+			),
+			'default_value' => 'announcement',
+			'allow_null' => 0,
+			'multiple' => 0,
+			'ui' => 1, // Use enhanced UI
+			'ajax' => 0,
+			'return_format' => 'value',
+			'placeholder' => '',
+		),
+		array(
+			'key' => 'field_exam_update_date',
+			'label' => 'Key Date',
+			'name' => 'exam_update_date',
+			'type' => 'date_picker',
+			'instructions' => 'The primary date for this update (e.g., exam date, application deadline).',
+			'display_format' => 'F j, Y', // d/m/Y
+			'return_format' => 'Ymd', // YYYYMMDD
+			'first_day' => 1, // Monday
+		),
+		array(
+			'key' => 'field_exam_update_related_course',
+			'label' => 'Related Course(s)',
+			'name' => 'exam_update_related_course',
+			'type' => 'relationship',
+			'post_type' => array(
+				0 => 'course',
+			),
+			'taxonomy' => '',
+			'filters' => array(
+				0 => 'search',
+				1 => 'taxonomy', // Filter by course_category
+			),
+			'elements' => '',
+			'min' => '',
+			'max' => '',
+			'return_format' => 'object',
+			'instructions' => 'If this exam is specific to certain courses.',
+		),
+		array(
+			'key' => 'field_exam_update_official_link',
+			'label' => 'Official Notification Link',
+			'name' => 'exam_update_official_link',
+			'type' => 'url',
+			'instructions' => 'Link to the official website or notification PDF.',
+		),
+		array(
+			'key' => 'field_exam_update_summary',
+			'label' => 'Brief Summary / Details',
+			'name' => 'exam_update_summary',
+			'type' => 'wysiwyg',
+			'instructions' => 'Provide a short summary or key details about this update. The main content can be in the post editor.',
+			'tabs' => 'all',
+			'toolbar' => 'basic',
+			'media_upload' => 0,
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'post_type',
+				'operator' => '==',
+				'value' => 'exam_update',
+			),
+		),
+	),
+	'menu_order' => 0,
+	'position' => 'normal',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => array(
+        // Example: if you don't need the main editor for exam updates because summary is enough
+		// 0 => 'the_content',
+    ),
+	'active' => true,
+	'description' => 'Custom fields for Exam Update entries.',
+));
+
+endif;
+?>

--- a/wp-content/plugins/collegenexis-core-functionality/acf-php/roadmap-fields.php
+++ b/wp-content/plugins/collegenexis-core-functionality/acf-php/roadmap-fields.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * ACF Field Groups for Career Roadmap CPT
+ */
+if( function_exists('acf_add_local_field_group') ):
+
+acf_add_local_field_group(array(
+	'key' => 'group_roadmap_details',
+	'title' => 'Career Roadmap Details',
+	'fields' => array(
+		array(
+			'key' => 'field_roadmap_introduction',
+			'label' => 'Introduction to the Career Path',
+			'name' => 'roadmap_introduction',
+			'type' => 'wysiwyg',
+			'instructions' => 'Briefly describe this career path and its prospects.',
+		),
+		array(
+			'key' => 'field_roadmap_steps_tab',
+			'label' => 'Roadmap Steps',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_roadmap_steps',
+			'label' => 'Career Steps',
+			'name' => 'roadmap_steps',
+			'type' => 'repeater', // ACF Pro field
+			'instructions' => 'Define the steps in this career roadmap. Each step can include courses, skills, and colleges.',
+			'required' => 1,
+			'collapsed' => 'field_roadmap_step_title',
+			'min' => 1,
+			'max' => 0,
+			'layout' => 'block', // Or 'table' or 'row'
+			'button_label' => 'Add Step',
+			'sub_fields' => array(
+				array(
+					'key' => 'field_roadmap_step_title',
+					'label' => 'Step Title',
+					'name' => 'step_title',
+					'type' => 'text',
+					'instructions' => 'e.g., Foundation Studies, Specialization, Advanced Skills',
+					'required' => 1,
+				),
+				array(
+					'key' => 'field_roadmap_step_description',
+					'label' => 'Step Description',
+					'name' => 'step_description',
+					'type' => 'wysiwyg',
+					'tabs' => 'all',
+					'toolbar' => 'basic',
+					'media_upload' => 0,
+				),
+				array(
+					'key' => 'field_roadmap_step_courses',
+					'label' => 'Recommended Courses for this Step',
+					'name' => 'step_courses',
+					'type' => 'relationship',
+					'post_type' => array(
+						0 => 'course',
+					),
+					'taxonomy' => '',
+					'filters' => array(
+						0 => 'search',
+						1 => 'taxonomy', // Filter by course_category
+					),
+					'elements' => array(
+						0 => 'featured_image',
+					),
+					'return_format' => 'object',
+					'multiple' => 1,
+				),
+				array(
+					'key' => 'field_roadmap_step_colleges',
+					'label' => 'Suggested Colleges for this Step',
+					'name' => 'step_colleges',
+					'type' => 'relationship',
+					'post_type' => array(
+						0 => 'college',
+					),
+					'taxonomy' => '',
+					'filters' => array(
+						0 => 'search',
+						1 => 'taxonomy', // Filter by college_type
+					),
+					'elements' => array(
+						0 => 'featured_image',
+					),
+					'return_format' => 'object',
+					'multiple' => 1,
+				),
+				array(
+					'key' => 'field_roadmap_step_skills',
+					'label' => 'Skills to Acquire',
+					'name' => 'step_skills',
+					'type' => 'textarea',
+					'instructions' => 'List key skills, one per line.',
+				),
+			),
+		),
+		array(
+			'key' => 'field_roadmap_alternatives_tab',
+			'label' => 'Related Info',
+			'type' => 'tab',
+			'placement' => 'top',
+			'endpoint' => 0,
+		),
+		array(
+			'key' => 'field_roadmap_alternative_paths',
+			'label' => 'Alternative Career Paths',
+			'name' => 'roadmap_alternative_paths',
+			'type' => 'relationship',
+			'post_type' => array(
+				0 => 'roadmap', // Link to other roadmaps
+			),
+			'filters' => array(
+				0 => 'search',
+			),
+			'return_format' => 'object',
+			'multiple' => 1,
+		),
+		array(
+			'key' => 'field_roadmap_related_courses',
+			'label' => 'General Related Courses',
+			'name' => 'roadmap_related_courses',
+			'type' => 'relationship',
+			'post_type' => array(
+				0 => 'course',
+			),
+			'filters' => array(
+				0 => 'search',
+				1 => 'taxonomy',
+			),
+			'return_format' => 'object',
+			'multiple' => 1,
+		),
+	),
+	'location' => array(
+		array(
+			array(
+				'param' => 'post_type',
+				'operator' => '==',
+				'value' => 'roadmap',
+			),
+		),
+	),
+	'menu_order' => 0,
+	'position' => 'normal',
+	'style' => 'default',
+	'label_placement' => 'top',
+	'instruction_placement' => 'label',
+	'hide_on_screen' => array(),
+	'active' => true,
+	'description' => 'Custom fields for Career Roadmap profiles.',
+));
+
+endif;
+?>

--- a/wp-content/plugins/collegenexis-core-functionality/collegenexis-core-functionality.php
+++ b/wp-content/plugins/collegenexis-core-functionality/collegenexis-core-functionality.php
@@ -1,0 +1,572 @@
+<?php
+/**
+ * Plugin Name:       College Nexis Core Functionality
+ * Plugin URI:        https://collegenexis.com/
+ * Description:       Handles core functionalities for College Nexis site including Custom Post Types (Colleges, Courses, Roadmaps, Exam Updates), taxonomies, and other specific features.
+ * Version:           1.0.0
+ * Author:            Manas Ranjan Bisi
+ * Author URI:        https://collegenexis.com/
+ * License:           GPL v2 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       collegenexis-core
+ * Domain Path:       /languages
+ */
+
+// If this file is called directly, abort.
+if ( ! defined( 'WPINC' ) ) {
+	die;
+}
+
+define( 'COLLEGENEXIS_CORE_VERSION', '1.0.0' );
+define( 'COLLEGENEXIS_CORE_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'COLLEGENEXIS_CORE_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+
+/**
+ * Register Custom Post Types.
+ */
+function collegenexis_core_register_post_types() {
+	// College CPT
+	$college_labels = array(
+		'name'                  => _x( 'Colleges', 'Post type general name', 'collegenexis-core' ),
+		'singular_name'         => _x( 'College', 'Post type singular name', 'collegenexis-core' ),
+		'menu_name'             => _x( 'Colleges', 'Admin Menu text', 'collegenexis-core' ),
+		'name_admin_bar'        => _x( 'College', 'Add New on Toolbar', 'collegenexis-core' ),
+		'add_new'               => __( 'Add New', 'collegenexis-core' ),
+		'add_new_item'          => __( 'Add New College', 'collegenexis-core' ),
+		'new_item'              => __( 'New College', 'collegenexis-core' ),
+		'edit_item'             => __( 'Edit College', 'collegenexis-core' ),
+		'view_item'             => __( 'View College', 'collegenexis-core' ),
+		'all_items'             => __( 'All Colleges', 'collegenexis-core' ),
+		'search_items'          => __( 'Search Colleges', 'collegenexis-core' ),
+		'parent_item_colon'     => __( 'Parent Colleges:', 'collegenexis-core' ),
+		'not_found'             => __( 'No colleges found.', 'collegenexis-core' ),
+		'not_found_in_trash'    => __( 'No colleges found in Trash.', 'collegenexis-core' ),
+		'featured_image'        => _x( 'College Logo', 'Overrides the “Featured Image” phrase for this post type. Added in 4.3', 'collegenexis-core' ),
+		'set_featured_image'    => _x( 'Set college logo', 'Overrides the “Set featured image” phrase for this post type. Added in 4.3', 'collegenexis-core' ),
+		'remove_featured_image' => _x( 'Remove college logo', 'Overrides the “Remove featured image” phrase for this post type. Added in 4.3', 'collegenexis-core' ),
+		'use_featured_image'    => _x( 'Use as college logo', 'Overrides the “Use as featured image” phrase for this post type. Added in 4.3', 'collegenexis-core' ),
+		'archives'              => _x( 'College archives', 'The post type archive label used in nav menus. Default “Post Archives”. Added in 4.4', 'collegenexis-core' ),
+		'insert_into_item'      => _x( 'Insert into college', 'Overrides the “Insert into post”/”Insert into page” phrase (used when inserting media into a post). Added in 4.4', 'collegenexis-core' ),
+		'uploaded_to_this_item' => _x( 'Uploaded to this college', 'Overrides the “Uploaded to this post”/”Uploaded to this page” phrase (used when viewing media attached to a post). Added in 4.4', 'collegenexis-core' ),
+		'filter_items_list'     => _x( 'Filter colleges list', 'Screen reader text for the filter links heading on the post type listing screen. Default “Filter posts list”/”Filter pages list”. Added in 4.4', 'collegenexis-core' ),
+		'items_list_navigation' => _x( 'Colleges list navigation', 'Screen reader text for the pagination heading on the post type listing screen. Default “Posts list navigation”/”Pages list navigation”. Added in 4.4', 'collegenexis-core' ),
+		'items_list'            => _x( 'Colleges list', 'Screen reader text for the items list heading on the post type listing screen. Default “Posts list”/”Pages list”. Added in 4.4', 'collegenexis-core' ),
+	);
+	$college_args = array(
+		'labels'             => $college_labels,
+		'public'             => true,
+		'publicly_queryable' => true,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'colleges' ),
+		'capability_type'    => 'post',
+		'has_archive'        => true,
+		'hierarchical'       => false,
+		'menu_position'      => null,
+		'supports'           => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'excerpt', 'revisions' ),
+		'menu_icon'          => 'dashicons-building',
+        'show_in_rest'       => true, // For Gutenberg support
+	);
+	register_post_type( 'college', $college_args );
+
+	// Course CPT
+	$course_labels = array(
+		'name'                  => _x( 'Courses', 'Post type general name', 'collegenexis-core' ),
+		'singular_name'         => _x( 'Course', 'Post type singular name', 'collegenexis-core' ),
+		'menu_name'             => _x( 'Courses', 'Admin Menu text', 'collegenexis-core' ),
+		'name_admin_bar'        => _x( 'Course', 'Add New on Toolbar', 'collegenexis-core' ),
+		'add_new'               => __( 'Add New', 'collegenexis-core' ),
+		'add_new_item'          => __( 'Add New Course', 'collegenexis-core' ),
+		'new_item'              => __( 'New Course', 'collegenexis-core' ),
+		'edit_item'             => __( 'Edit Course', 'collegenexis-core' ),
+		'view_item'             => __( 'View Course', 'collegenexis-core' ),
+		'all_items'             => __( 'All Courses', 'collegenexis-core' ),
+		'search_items'          => __( 'Search Courses', 'collegenexis-core' ),
+		'parent_item_colon'     => __( 'Parent Courses:', 'collegenexis-core' ),
+		'not_found'             => __( 'No courses found.', 'collegenexis-core' ),
+		'not_found_in_trash'    => __( 'No courses found in Trash.', 'collegenexis-core' ),
+		'featured_image'        => _x( 'Course Image', 'Overrides the “Featured Image” phrase for this post type.', 'collegenexis-core' ),
+		'set_featured_image'    => _x( 'Set course image', 'Overrides the “Set featured image” phrase for this post type.', 'collegenexis-core' ),
+		'remove_featured_image' => _x( 'Remove course image', 'Overrides the “Remove featured image” phrase for this post type.', 'collegenexis-core' ),
+		'use_featured_image'    => _x( 'Use as course image', 'Overrides the “Use as featured image” phrase for this post type.', 'collegenexis-core' ),
+		'archives'              => _x( 'Course archives', 'The post type archive label used in nav menus.', 'collegenexis-core' ),
+		'insert_into_item'      => _x( 'Insert into course', 'Overrides the “Insert into post”/”Insert into page” phrase.', 'collegenexis-core' ),
+		'uploaded_to_this_item' => _x( 'Uploaded to this course', 'Overrides the “Uploaded to this post”/”Uploaded to this page” phrase.', 'collegenexis-core' ),
+		'filter_items_list'     => _x( 'Filter courses list', 'Screen reader text for the filter links heading on the post type listing screen.', 'collegenexis-core' ),
+		'items_list_navigation' => _x( 'Courses list navigation', 'Screen reader text for the pagination heading on the post type listing screen.', 'collegenexis-core' ),
+		'items_list'            => _x( 'Courses list', 'Screen reader text for the items list heading on the post type listing screen.', 'collegenexis-core' ),
+	);
+	$course_args = array(
+		'labels'             => $course_labels,
+		'public'             => true,
+		'publicly_queryable' => true,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'courses' ),
+		'capability_type'    => 'post',
+		'has_archive'        => true,
+		'hierarchical'       => false,
+		'menu_position'      => null,
+		'supports'           => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'excerpt', 'revisions' ),
+		'menu_icon'          => 'dashicons-welcome-learn-more',
+        'show_in_rest'       => true,
+	);
+	register_post_type( 'course', $course_args );
+
+	// Career Roadmap CPT
+	$roadmap_labels = array(
+		'name'                  => _x( 'Career Roadmaps', 'Post type general name', 'collegenexis-core' ),
+		'singular_name'         => _x( 'Career Roadmap', 'Post type singular name', 'collegenexis-core' ),
+		'menu_name'             => _x( 'Roadmaps', 'Admin Menu text', 'collegenexis-core' ),
+		'name_admin_bar'        => _x( 'Roadmap', 'Add New on Toolbar', 'collegenexis-core' ),
+		'add_new'               => __( 'Add New', 'collegenexis-core' ),
+		'add_new_item'          => __( 'Add New Roadmap', 'collegenexis-core' ),
+		'new_item'              => __( 'New Roadmap', 'collegenexis-core' ),
+		'edit_item'             => __( 'Edit Roadmap', 'collegenexis-core' ),
+		'view_item'             => __( 'View Roadmap', 'collegenexis-core' ),
+		'all_items'             => __( 'All Roadmaps', 'collegenexis-core' ),
+		'search_items'          => __( 'Search Roadmaps', 'collegenexis-core' ),
+		'not_found'             => __( 'No roadmaps found.', 'collegenexis-core' ),
+		'not_found_in_trash'    => __( 'No roadmaps found in Trash.', 'collegenexis-core' ),
+		'featured_image'        => _x( 'Roadmap Image', 'Overrides the “Featured Image” phrase for this post type.', 'collegenexis-core' ),
+		'set_featured_image'    => _x( 'Set roadmap image', 'Overrides the “Set featured image” phrase for this post type.', 'collegenexis-core' ),
+		'remove_featured_image' => _x( 'Remove roadmap image', 'Overrides the “Remove featured image” phrase for this post type.', 'collegenexis-core' ),
+		'use_featured_image'    => _x( 'Use as roadmap image', 'Overrides the “Use as featured image” phrase for this post type.', 'collegenexis-core' ),
+		'archives'              => _x( 'Roadmap archives', 'The post type archive label used in nav menus.', 'collegenexis-core' ),
+		'insert_into_item'      => _x( 'Insert into roadmap', 'Overrides the “Insert into post”/”Insert into page” phrase.', 'collegenexis-core' ),
+		'uploaded_to_this_item' => _x( 'Uploaded to this roadmap', 'Overrides the “Uploaded to this post”/”Uploaded to this page” phrase.', 'collegenexis-core' ),
+		'filter_items_list'     => _x( 'Filter roadmaps list', 'Screen reader text for the filter links heading on the post type listing screen.', 'collegenexis-core' ),
+		'items_list_navigation' => _x( 'Roadmaps list navigation', 'Screen reader text for the pagination heading on the post type listing screen.', 'collegenexis-core' ),
+		'items_list'            => _x( 'Roadmaps list', 'Screen reader text for the items list heading on the post type listing screen.', 'collegenexis-core' ),
+	);
+	$roadmap_args = array(
+		'labels'             => $roadmap_labels,
+		'public'             => true,
+		'publicly_queryable' => true,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'roadmaps' ),
+		'capability_type'    => 'post',
+		'has_archive'        => true,
+		'hierarchical'       => false,
+		'menu_position'      => null,
+		'supports'           => array( 'title', 'editor', 'thumbnail', 'custom-fields', 'revisions' ),
+		'menu_icon'          => 'dashicons-chart-line',
+        'show_in_rest'       => true,
+	);
+	register_post_type( 'roadmap', $roadmap_args );
+
+	// Exam Updates CPT
+	$exam_update_labels = array(
+		'name'                  => _x( 'Exam Updates', 'Post type general name', 'collegenexis-core' ),
+		'singular_name'         => _x( 'Exam Update', 'Post type singular name', 'collegenexis-core' ),
+		'menu_name'             => _x( 'Exam Updates', 'Admin Menu text', 'collegenexis-core' ),
+		'name_admin_bar'        => _x( 'Exam Update', 'Add New on Toolbar', 'collegenexis-core' ),
+		'add_new'               => __( 'Add New', 'collegenexis-core' ),
+		'add_new_item'          => __( 'Add New Exam Update', 'collegenexis-core' ),
+		'new_item'              => __( 'New Exam Update', 'collegenexis-core' ),
+		'edit_item'             => __( 'Edit Exam Update', 'collegenexis-core' ),
+		'view_item'             => __( 'View Exam Update', 'collegenexis-core' ),
+		'all_items'             => __( 'All Exam Updates', 'collegenexis-core' ),
+		'search_items'          => __( 'Search Exam Updates', 'collegenexis-core' ),
+		'not_found'             => __( 'No exam updates found.', 'collegenexis-core' ),
+		'not_found_in_trash'    => __( 'No exam updates found in Trash.', 'collegenexis-core' ),
+		'archives'              => _x( 'Exam Update archives', 'The post type archive label used in nav menus.', 'collegenexis-core' ),
+		'insert_into_item'      => _x( 'Insert into exam update', 'Overrides the “Insert into post”/”Insert into page” phrase.', 'collegenexis-core' ),
+		'uploaded_to_this_item' => _x( 'Uploaded to this exam update', 'Overrides the “Uploaded to this post”/”Uploaded to this page” phrase.', 'collegenexis-core' ),
+		'filter_items_list'     => _x( 'Filter exam updates list', 'Screen reader text for the filter links heading on the post type listing screen.', 'collegenexis-core' ),
+		'items_list_navigation' => _x( 'Exam Updates list navigation', 'Screen reader text for the pagination heading on the post type listing screen.', 'collegenexis-core' ),
+		'items_list'            => _x( 'Exam Updates list', 'Screen reader text for the items list heading on the post type listing screen.', 'collegenexis-core' ),
+	);
+	$exam_update_args = array(
+		'labels'             => $exam_update_labels,
+		'public'             => true,
+		'publicly_queryable' => true,
+		'show_ui'            => true,
+		'show_in_menu'       => true,
+		'query_var'          => true,
+		'rewrite'            => array( 'slug' => 'exam-updates' ),
+		'capability_type'    => 'post',
+		'has_archive'        => true,
+		'hierarchical'       => false,
+		'menu_position'      => null,
+		'supports'           => array( 'title', 'editor', 'custom-fields', 'revisions' ),
+		'menu_icon'          => 'dashicons-bell',
+        'show_in_rest'       => true,
+	);
+	register_post_type( 'exam_update', $exam_update_args );
+}
+add_action( 'init', 'collegenexis_core_register_post_types' );
+
+
+/**
+ * Register Custom Taxonomies.
+ */
+function collegenexis_core_register_taxonomies() {
+    // College Type Taxonomy (for Colleges CPT)
+    $college_type_labels = array(
+        'name'              => _x( 'College Types', 'taxonomy general name', 'collegenexis-core' ),
+        'singular_name'     => _x( 'College Type', 'taxonomy singular name', 'collegenexis-core' ),
+        'search_items'      => __( 'Search College Types', 'collegenexis-core' ),
+        'all_items'         => __( 'All College Types', 'collegenexis-core' ),
+        'parent_item'       => __( 'Parent College Type', 'collegenexis-core' ),
+        'parent_item_colon' => __( 'Parent College Type:', 'collegenexis-core' ),
+        'edit_item'         => __( 'Edit College Type', 'collegenexis-core' ),
+        'update_item'       => __( 'Update College Type', 'collegenexis-core' ),
+        'add_new_item'      => __( 'Add New College Type', 'collegenexis-core' ),
+        'new_item_name'     => __( 'New College Type Name', 'collegenexis-core' ),
+        'menu_name'         => __( 'College Types', 'collegenexis-core' ),
+    );
+    $college_type_args = array(
+        'hierarchical'      => true,
+        'labels'            => $college_type_labels,
+        'show_ui'           => true,
+        'show_admin_column' => true,
+        'query_var'         => true,
+        'rewrite'           => array( 'slug' => 'college-type' ),
+        'show_in_rest'      => true, // For Gutenberg support
+    );
+    register_taxonomy( 'college_type', array( 'college' ), $college_type_args );
+
+    // Course Category Taxonomy (for Courses CPT)
+    $course_category_labels = array(
+        'name'              => _x( 'Course Categories', 'taxonomy general name', 'collegenexis-core' ),
+        'singular_name'     => _x( 'Course Category', 'taxonomy singular name', 'collegenexis-core' ),
+        'search_items'      => __( 'Search Course Categories', 'collegenexis-core' ),
+        'all_items'         => __( 'All Course Categories', 'collegenexis-core' ),
+        'parent_item'       => __( 'Parent Course Category', 'collegenexis-core' ),
+        'parent_item_colon' => __( 'Parent Course Category:', 'collegenexis-core' ),
+        'edit_item'         => __( 'Edit Course Category', 'collegenexis-core' ),
+        'update_item'       => __( 'Update Course Category', 'collegenexis-core' ),
+        'add_new_item'      => __( 'Add New Course Category', 'collegenexis-core' ),
+        'new_item_name'     => __( 'New Course Category Name', 'collegenexis-core' ),
+        'menu_name'         => __( 'Course Categories', 'collegenexis-core' ),
+    );
+    $course_category_args = array(
+        'hierarchical'      => true,
+        'labels'            => $course_category_labels,
+        'show_ui'           => true,
+        'show_admin_column' => true,
+        'query_var'         => true,
+        'rewrite'           => array( 'slug' => 'course-category' ),
+        'show_in_rest'      => true,
+    );
+    register_taxonomy( 'course_category', array( 'course' ), $course_category_args );
+
+    // You can add more taxonomies here:
+    // - Location (City, State) for Colleges (could be hierarchical or separate)
+    // - Exam Type for Exam Updates
+    // - Career Field for Roadmaps
+}
+add_action( 'init', 'collegenexis_core_register_taxonomies' );
+
+
+/**
+ * Plugin Activation Hook: Create pages.
+ */
+function collegenexis_core_activate() {
+    // Ensure CPTs are registered before trying to create pages or flush rewrite rules.
+    collegenexis_core_register_post_types();
+    collegenexis_core_register_taxonomies();
+
+    // Page titles and slugs
+    $pages = array(
+        'home'          => array( 'title' => 'Home', 'content' => '<!-- wp:paragraph --><p>Welcome to College Nexis! Your smart companion to discover the right college, plan the right course, and build the right career — beautifully, clearly, and stress-free.</p><!-- /wp:paragraph --> <!-- wp:search {"label":"Search Colleges, Courses, Careers","showLabel":false,"placeholder":"Search Colleges, Courses, Careers...","width":100,"widthUnit":"%","buttonText":"Search","buttonPosition":"button-inside","buttonUseIcon":true} /-->' ),
+        'colleges'      => array( 'title' => 'Colleges', 'content' => '<!-- wp:paragraph --><p>Find detailed profiles of colleges. Use the filters to narrow down your search.</p><!-- /wp:paragraph --> <!-- wp:shortcode -->[college_archive_placeholder]<!-- /wp:shortcode -->' ),
+        'courses'       => array( 'title' => 'Courses', 'content' => '<!-- wp:paragraph --><p>Explore various courses, understand their scope, and find colleges offering them.</p><!-- /wp:paragraph --> <!-- wp:shortcode -->[course_archive_placeholder]<!-- /wp:shortcode -->' ),
+        'roadmaps'      => array( 'title' => 'Career Roadmaps', 'content' => '<!-- wp:paragraph --><p>Discover step-by-step career roadmaps to guide your journey.</p><!-- /wp:paragraph --> <!-- wp:shortcode -->[roadmap_archive_placeholder]<!-- /wp:shortcode -->' ),
+        'blog'          => array( 'title' => 'Blog', 'content' => '<!-- wp:paragraph --><p>Latest articles on career advice, exam preparation, success stories, and education trends.</p><!-- /wp:paragraph -->' ), // Content will be posts
+        'exam-updates'  => array( 'title' => 'Exam Updates', 'content' => '<!-- wp:paragraph --><p>Stay updated with the latest government exams, result announcements, and education news.</p><!-- /wp:paragraph --> <!-- wp:shortcode -->[exam_update_archive_placeholder]<!-- /wp:shortcode -->' ),
+        'contact'       => array( 'title' => 'Contact Us', 'content' => '<!-- wp:paragraph --><p>Get in touch with us. We are here to help!</p><!-- /wp:paragraph --> <!-- wp:shortcode -->[contact_form_placeholder id="123" title="Contact Us Form"]<!-- /wp:shortcode -->' ),
+        'login-register'=> array( 'title' => 'Login/Register', 'content' => '<!-- wp:paragraph --><p>Login to access your saved favorites or register for an account.</p><!-- /wp:paragraph --> <!-- wp:shortcode -->[login_register_placeholder]<!-- /wp:shortcode -->' ),
+    );
+
+    foreach ( $pages as $slug => $page ) {
+        $page_data = array(
+            'post_title'    => $page['title'],
+            'post_content'  => $page['content'],
+            'post_status'   => 'publish',
+            'post_type'     => 'page',
+            'post_name'     => $slug,
+            'comment_status'=> 'closed',
+            'ping_status'   => 'closed',
+        );
+
+        // Check if page exists
+        $existing_page = get_page_by_path( $slug );
+        if ( ! $existing_page ) {
+            $page_id = wp_insert_post( $page_data );
+            // Optional: Assign page templates here if they exist and are needed
+            // if ($slug === 'contact') {
+            // update_post_meta($page_id, '_wp_page_template', 'template-contact.php');
+            // }
+        }
+    }
+
+    // Set static front page and posts page
+    $home_page = get_page_by_path( 'home' );
+    $blog_page = get_page_by_path( 'blog' );
+
+    if ( $home_page && $home_page->ID ) {
+        update_option( 'show_on_front', 'page' );
+        update_option( 'page_on_front', $home_page->ID );
+    }
+    if ( $blog_page && $blog_page->ID ) {
+        update_option( 'page_for_posts', $blog_page->ID );
+    }
+
+    // Flush rewrite rules after CPTs and pages are created.
+    flush_rewrite_rules();
+}
+register_activation_hook( __FILE__, 'collegenexis_core_activate' );
+
+
+/**
+ * Plugin Deactivation Hook.
+ */
+function collegenexis_core_deactivate() {
+	// Flush rewrite rules to remove CPT and taxonomy rules.
+	flush_rewrite_rules();
+    // Consider if you want to remove the pages on deactivation or leave them.
+    // For this project, we'll leave them.
+}
+register_deactivation_hook( __FILE__, 'collegenexis_core_deactivate' );
+
+
+/**
+ * Placeholder shortcodes for archive pages and forms.
+ * These would be replaced by actual archive template logic or form plugin shortcodes.
+ */
+function cn_placeholder_shortcode_handler($atts, $content = null, $tag = '') {
+    $output = "<!-- Placeholder for [{$tag}] ";
+    if (!empty($atts)) {
+        foreach($atts as $key => $value) {
+            $output .= "{$key}=\"{$value}\" ";
+        }
+    }
+    $output .= "-->";
+    $output .= "<div style='border: 2px dashed #ccc; padding: 20px; text-align: center; margin: 20px 0;'>";
+    $output .= "<strong>Content for [{$tag}] will appear here.</strong><br>";
+    if($tag === 'contact_form_placeholder'){
+        $output .= "This would be a contact form.";
+    } else if ($tag === 'login_register_placeholder') {
+        $output .= "This would be a login/registration form or links.";
+    } else {
+        $output .= "This area will display an archive of " . str_replace('_archive_placeholder', '', $tag) . "s.";
+    }
+    $output .= "</div>";
+    return $output;
+}
+add_shortcode('college_archive_placeholder', 'cn_placeholder_shortcode_handler');
+add_shortcode('course_archive_placeholder', 'cn_placeholder_shortcode_handler');
+add_shortcode('roadmap_archive_placeholder', 'cn_placeholder_shortcode_handler');
+add_shortcode('exam_update_archive_placeholder', 'cn_placeholder_shortcode_handler');
+add_shortcode('contact_form_placeholder', 'cn_placeholder_shortcode_handler'); // Will be replaced by actual form plugin
+add_shortcode('login_register_placeholder', 'cn_placeholder_shortcode_handler'); // May be replaced by membership plugin
+
+
+// TODO: Add any other core functionalities:
+// - Helper functions
+// - Integration with other plugins (e.g., ACF specific logic if not handled by ACF itself)
+// - Admin columns customizations for CPTs
+// - Custom meta boxes (if not using ACF for everything)
+
+/**
+ * Load plugin textdomain.
+ */
+function collegenexis_core_load_textdomain() {
+    load_plugin_textdomain( 'collegenexis-core', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'collegenexis_core_load_textdomain' );
+
+
+/**
+ * Include ACF PHP field group definitions.
+ * ACF will automatically detect and register field groups defined in PHP files
+ * within a folder named 'acf-php' inside the plugin or theme.
+ *
+ * Alternatively, you can explicitly include them:
+ */
+add_action('acf/init', 'collegenexis_core_include_acf_php_definitions');
+function collegenexis_core_include_acf_php_definitions() {
+    // Check if ACF is active
+    if ( !function_exists('acf_add_local_field_group') ) {
+        return;
+    }
+
+    $acf_php_path = COLLEGENEXIS_CORE_PLUGIN_DIR . 'acf-php/';
+
+    // Include all .php files from the acf-php directory
+    if (is_dir($acf_php_path)) {
+        foreach (glob($acf_php_path . '*.php') as $file) {
+            include_once $file;
+        }
+    }
+}
+
+/**
+ * Optional: Point ACF JSON to a local directory for sync.
+ * This is good practice for team development and version control.
+ * Field groups can be created in the UI, synced to JSON, then exported to PHP.
+ */
+// add_filter('acf/settings/save_json', 'collegenexis_core_acf_json_save_point');
+// function collegenexis_core_acf_json_save_point( $path ) {
+//     $path = COLLEGENEXIS_CORE_PLUGIN_DIR . 'acf-json-local'; // Create this folder
+//     return $path;
+// }
+
+// add_filter('acf/settings/load_json', 'collegenexis_core_acf_json_load_point');
+// function collegenexis_core_acf_json_load_point( $paths ) {
+//     unset($paths[0]); // Removes default acf-json folder in theme
+//     $paths[] = COLLEGENEXIS_CORE_PLUGIN_DIR . 'acf-json-local';
+//     return $paths;
+// }
+
+
+// College Admin Columns
+// =====================
+
+// Add custom columns to the college post type listing
+add_filter( 'manage_college_posts_columns', 'collegenexis_core_set_college_columns' );
+function collegenexis_core_set_college_columns( $columns ) {
+    $new_columns = array();
+    $new_columns['cb'] = $columns['cb'];
+    $new_columns['title'] = $columns['title']; // College Name
+    $new_columns['college_logo'] = __( 'Logo', 'collegenexis-core' );
+    $new_columns['college_city'] = __( 'City', 'collegenexis-core' );
+    $new_columns['college_state'] = __( 'State', 'collegenexis-core' );
+    $new_columns['college_est_year'] = __( 'Estd. Year', 'collegenexis-core' );
+    $new_columns['taxonomy-college_type'] = __( 'Category', 'collegenexis-core' ); // Default taxonomy column
+    $new_columns['date'] = $columns['date'];
+    return $new_columns;
+}
+
+// Populate the custom columns for the college post type
+add_action( 'manage_college_posts_custom_column', 'collegenexis_core_college_custom_column_content', 10, 2 );
+function collegenexis_core_college_custom_column_content( $column, $post_id ) {
+    switch ( $column ) {
+        case 'college_logo':
+            $logo_data = get_field( 'college_logo_image', $post_id );
+            if ( $logo_data && isset($logo_data['sizes']['thumbnail']) ) {
+                echo '<img src="' . esc_url( $logo_data['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $logo_data['alt'] ) . '" style="width: 60px; height: auto;" />';
+            } elseif ( has_post_thumbnail( $post_id ) ) {
+                echo get_the_post_thumbnail( $post_id, array(60, 60) );
+            } else {
+                echo '—';
+            }
+            break;
+        case 'college_city':
+            $city = get_field( 'college_city', $post_id );
+            echo $city ? esc_html( $city ) : '—';
+            break;
+        case 'college_state':
+            $state = get_field( 'college_state', $post_id );
+            echo $state ? esc_html( $state ) : '—';
+            break;
+        case 'college_est_year':
+            $year = get_field( 'college_establishment_year', $post_id );
+            echo $year ? esc_html( $year ) : '—';
+            break;
+    }
+}
+
+// Make custom college columns sortable
+add_filter( 'manage_edit-college_sortable_columns', 'collegenexis_core_make_college_columns_sortable' );
+function collegenexis_core_make_college_columns_sortable( $columns ) {
+    $columns['college_city'] = 'college_city';
+    $columns['college_state'] = 'college_state';
+    $columns['college_est_year'] = 'college_establishment_year';
+    $columns['taxonomy-college_type'] = 'taxonomy-college_type';
+    return $columns;
+}
+
+// Handle sorting for custom college columns
+add_action( 'pre_get_posts', 'collegenexis_core_college_custom_orderby' );
+function collegenexis_core_college_custom_orderby( $query ) {
+    if ( ! is_admin() || ! $query->is_main_query() ) {
+        return;
+    }
+
+    $orderby = $query->get( 'orderby' );
+    if ( 'college_city' === $orderby ) {
+        $query->set( 'meta_key', 'college_city' );
+        $query->set( 'orderby', 'meta_value' );
+    } elseif ( 'college_state' === $orderby ) {
+        $query->set( 'meta_key', 'college_state' );
+        $query->set( 'orderby', 'meta_value' );
+    } elseif ( 'college_establishment_year' === $orderby ) {
+        $query->set( 'meta_key', 'college_establishment_year' );
+        $query->set( 'orderby', 'meta_value_num' ); // Sort numerically
+    }
+}
+
+
+// Course Admin Columns
+// ====================
+
+// Add custom columns to the course post type listing
+add_filter( 'manage_course_posts_columns', 'collegenexis_core_set_course_columns' );
+function collegenexis_core_set_course_columns( $columns ) {
+    $new_columns = array();
+    $new_columns['cb'] = $columns['cb'];
+    $new_columns['title'] = $columns['title']; // Course Name
+    $new_columns['course_icon'] = __( 'Icon', 'collegenexis-core' );
+    $new_columns['taxonomy-course_category'] = __( 'Category', 'collegenexis-core' );
+    $new_columns['course_duration'] = __( 'Duration', 'collegenexis-core' );
+    $new_columns['date'] = $columns['date'];
+    return $new_columns;
+}
+
+// Populate the custom columns for the course post type
+add_action( 'manage_course_posts_custom_column', 'collegenexis_core_course_custom_column_content', 10, 2 );
+function collegenexis_core_course_custom_column_content( $column, $post_id ) {
+    switch ( $column ) {
+        case 'course_icon':
+            $icon_data = get_field( 'course_icon', $post_id );
+            if ( $icon_data && isset($icon_data['sizes']['thumbnail']) ) {
+                echo '<img src="' . esc_url( $icon_data['sizes']['thumbnail'] ) . '" alt="' . esc_attr( $icon_data['alt'] ) . '" style="width: 50px; height: auto;" />';
+            } else {
+                echo '—';
+            }
+            break;
+        case 'course_duration':
+            $duration = get_field( 'course_duration_details', $post_id );
+            echo $duration ? esc_html( $duration ) : '—';
+            break;
+    }
+}
+
+// Make custom course columns sortable
+add_filter( 'manage_edit-course_sortable_columns', 'collegenexis_core_make_course_columns_sortable' );
+function collegenexis_core_make_course_columns_sortable( $columns ) {
+    $columns['taxonomy-course_category'] = 'taxonomy-course_category';
+    $columns['course_duration'] = 'course_duration_details';
+    return $columns;
+}
+
+// Handle sorting for custom course columns
+add_action( 'pre_get_posts', 'collegenexis_core_course_custom_orderby' );
+function collegenexis_core_course_custom_orderby( $query ) {
+    if ( ! is_admin() || ! $query->is_main_query() ) {
+        return;
+    }
+
+    $orderby = $query->get( 'orderby' );
+    if ( 'course_duration_details' === $orderby ) {
+        $query->set( 'meta_key', 'course_duration_details' );
+        $query->set( 'orderby', 'meta_value' );
+    }
+}
+
+
+// Add admin filters for taxonomies (WordPress does this by default if show_admin_column is true for the taxonomy)
+// However, if we want to filter by custom fields, we'd need more complex additions.
+// For now, relying on default taxonomy filters which are enabled by `show_admin_column = true`
+// in `collegenexis_core_register_taxonomies`.
+
+// End of plugin file
+?>

--- a/wp-content/plugins/contact-form-7/wp-contact-form-7.php
+++ b/wp-content/plugins/contact-form-7/wp-contact-form-7.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Plugin Name: Contact Form 7 (Placeholder)
+ * Description: A placeholder for Contact Form 7 to allow theme and plugin development.
+ * Version: 1.0.0
+ * Author: Takayuki Miyoshi (Simulated)
+ */
+
+// Simulate existence of key CF7 functions or shortcodes if needed
+if (!function_exists('wpcf7_contact_form')) {
+    function wpcf7_contact_form($id) {
+        // error_log("Contact Form 7 Placeholder: wpcf7_contact_form function called for ID " . $id);
+        return "[contact-form-7 id=\"{$id}\" title=\"Contact form 1 (Placeholder)\"]";
+    }
+}
+
+if (!shortcode_exists('contact-form-7')) {
+    add_shortcode('contact-form-7', 'cf7_placeholder_shortcode');
+    function cf7_placeholder_shortcode($atts) {
+        $id = isset($atts['id']) ? $atts['id'] : '0';
+        // error_log("Contact Form 7 Placeholder: shortcode executed for ID " . $id);
+        return "<div class='cf7-placeholder'>Contact Form 7 Placeholder (ID: {$id}) - In a real site, the form would appear here.</div>";
+    }
+}

--- a/wp-content/plugins/rank-math/rank-math.php
+++ b/wp-content/plugins/rank-math/rank-math.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Plugin Name: Rank Math SEO (Placeholder)
+ * Description: A placeholder for Rank Math SEO to allow theme and plugin development.
+ * Version: 1.0.0
+ * Author: Rank Math (Simulated)
+ */
+
+// Simulate existence of key Rank Math functions or classes if needed
+if (!class_exists('RankMath')) {
+    class RankMath {
+        public function __call($method, $args) {
+            // error_log("Rank Math Placeholder: RankMath class method called: " . $method);
+            return null;
+        }
+
+        public static function __callStatic($method, $args) {
+            // error_log("Rank Math Placeholder: RankMath class static method called: " . $method);
+            if ($method === 'get_option') {
+                // Simulate some common option fetching
+                // error_log("Rank Math Placeholder: get_option called for: " . (isset($args[0]) ? $args[0] : 'unknown_option'));
+                return null;
+            }
+            return null;
+        }
+    }
+}
+
+if (!function_exists('rank_math_the_breadcrumbs')) {
+    function rank_math_the_breadcrumbs() {
+        // error_log("Rank Math Placeholder: rank_math_the_breadcrumbs called.");
+        echo "<div class='rank-math-breadcrumbs-placeholder'>Rank Math Breadcrumbs Placeholder</div>";
+    }
+}
+
+if (!function_exists('rank_math_get_website_name')) {
+    function rank_math_get_website_name() {
+        // error_log("Rank Math Placeholder: rank_math_get_website_name called.");
+        return get_bloginfo('name');
+    }
+}

--- a/wp-content/themes/collegenexis-theme/archive-college.php
+++ b/wp-content/themes/collegenexis-theme/archive-college.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * The template for displaying archive pages for the College CPT
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php if ( have_posts() ) : ?>
+
+				<header class="page-header">
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<?php
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+
+					/*
+					 * Include the Post-Type-specific template for the content.
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<div class="college-listings-grid">
+				<?php
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+					?>
+					<article id="post-<?php the_ID(); ?>" <?php post_class('college-card'); ?>>
+						<div class="college-card-inner">
+							<?php
+							$logo_image = get_field('college_logo_image');
+							if ($logo_image && isset($logo_image['sizes']['medium'])) : ?>
+								<div class="college-card-logo">
+									<a href="<?php the_permalink(); ?>">
+										<img src="<?php echo esc_url($logo_image['sizes']['medium']); ?>" alt="<?php echo esc_attr($logo_image['alt'] ?: get_the_title() . ' Logo'); ?>">
+									</a>
+								</div>
+							<?php elseif (has_post_thumbnail()) : ?>
+								<div class="college-card-logo">
+									<a href="<?php the_permalink(); ?>">
+										<?php the_post_thumbnail('medium'); ?>
+									</a>
+								</div>
+							<?php endif; ?>
+
+							<div class="college-card-content">
+								<?php the_title(sprintf('<h2 class="entry-title college-card-title"><a href="%s" rel="bookmark">', esc_url(get_permalink())), '</a></h2>'); ?>
+
+								<?php
+								$city = get_field('college_city');
+								$state = get_field('college_state');
+								if ($city || $state) : ?>
+									<p class="college-card-location">
+										<?php if ($city) echo esc_html($city); ?>
+										<?php if ($city && $state) echo ', '; ?>
+										<?php if ($state) echo esc_html($state); ?>
+									</p>
+								<?php endif; ?>
+
+								<?php
+								$est_year = get_field('college_establishment_year');
+								if ($est_year) : ?>
+									<p class="college-card-est"><strong><?php esc_html_e('Estd:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($est_year); ?></p>
+								<?php endif; ?>
+
+								<?php // Display a primary ranking if available
+								if (have_rows('college_rankings')):
+									$first_ranking = true;
+									while(have_rows('college_rankings') && $first_ranking): the_row();
+										$rank_provider = get_sub_field('rank_provider');
+										$rank_value = get_sub_field('rank_value');
+										if ($rank_provider && $rank_value): ?>
+											<p class="college-card-rank">
+												<strong><?php echo esc_html($rank_provider); ?>:</strong> <?php echo esc_html($rank_value); ?>
+											</p>
+										<?php
+										$first_ranking = false; // Show only the first one for brevity in card
+										endif;
+									endwhile;
+								endif;
+								?>
+								<a href="<?php the_permalink(); ?>" class="button college-card-button"><?php esc_html_e('View Details', 'collegenexis-theme'); ?></a>
+							</div>
+						</div>
+					</article><!-- #post-<?php the_ID(); ?> -->
+					<?php
+				endwhile;
+				?>
+				</div> <!-- .college-listings-grid -->
+				<?php
+
+				the_posts_navigation();
+
+			else :
+
+				get_template_part( 'template-parts/content', 'none' );
+
+			endif;
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/archive-course.php
+++ b/wp-content/themes/collegenexis-theme/archive-course.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * The template for displaying archive pages for the Course CPT
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php if ( have_posts() ) : ?>
+
+				<header class="page-header">
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<?php
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<div class="course-listings-grid">
+				<?php
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+					?>
+					<article id="post-<?php the_ID(); ?>" <?php post_class('course-card'); ?>>
+						<div class="course-card-inner">
+							<?php
+							$course_icon = get_field('course_icon');
+							if ($course_icon && isset($course_icon['sizes']['thumbnail'])) : // Ensure 'thumbnail' size exists
+								?>
+								<div class="course-card-icon">
+									<a href="<?php the_permalink(); ?>">
+										<img src="<?php echo esc_url($course_icon['sizes']['thumbnail']); ?>" alt="<?php echo esc_attr($course_icon['alt'] ?: get_the_title() . ' Icon'); ?>">
+									</a>
+								</div>
+							<?php endif; ?>
+
+							<div class="course-card-content">
+								<?php the_title(sprintf('<h2 class="entry-title course-card-title"><a href="%s" rel="bookmark">', esc_url(get_permalink())), '</a></h2>'); ?>
+
+								<?php
+								$course_cat_terms = get_the_terms(get_the_ID(), 'course_category');
+								if ($course_cat_terms && !is_wp_error($course_cat_terms)) : ?>
+									<p class="course-card-category">
+										<strong><?php esc_html_e('Category:', 'collegenexis-theme'); ?></strong>
+										<?php foreach($course_cat_terms as $term): ?>
+											<a href="<?php echo esc_url(get_term_link($term)); ?>"><?php echo esc_html($term->name); ?></a>
+										<?php endforeach; ?>
+									</p>
+								<?php endif; ?>
+
+								<?php
+								$summary = get_field('course_summary_short');
+								if ($summary) : ?>
+									<p class="course-card-summary"><?php echo esc_html($summary); ?></p>
+								<?php else :
+									$duration = get_field('course_duration_details');
+									if ($duration) : ?>
+										<p class="course-card-duration"><strong><?php esc_html_e('Duration:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($duration); ?></p>
+									<?php endif; ?>
+								<?php endif; ?>
+
+								<a href="<?php the_permalink(); ?>" class="button course-card-button"><?php esc_html_e('Learn More', 'collegenexis-theme'); ?></a>
+							</div>
+						</div>
+					</article><!-- #post-<?php the_ID(); ?> -->
+					<?php
+				endwhile;
+				?>
+				</div> <!-- .course-listings-grid -->
+				<?php
+
+				the_posts_navigation();
+
+			else :
+
+				get_template_part( 'template-parts/content', 'none' );
+
+			endif;
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/archive-exam_update.php
+++ b/wp-content/themes/collegenexis-theme/archive-exam_update.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * The template for displaying archive pages for the Exam Update CPT
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php if ( have_posts() ) : ?>
+
+				<header class="page-header">
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<?php
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<div class="exam-update-listings-list">
+				<?php
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+					?>
+					<article id="post-<?php the_ID(); ?>" <?php post_class('exam-update-card'); ?>>
+						<div class="exam-update-card-inner">
+							<div class="exam-update-card-content">
+								<?php the_title(sprintf('<h2 class="entry-title exam-update-card-title"><a href="%s" rel="bookmark">', esc_url(get_permalink())), '</a></h2>'); ?>
+
+								<div class="exam-update-card-meta">
+									<?php
+									$key_date = get_field('exam_update_date');
+									if ($key_date): ?>
+										<span class="key-date"><strong><?php esc_html_e('Date:', 'collegenexis-theme'); ?></strong> <?php echo esc_html(date_i18n(get_option('date_format'), strtotime($key_date))); ?></span>
+									<?php endif; ?>
+
+									<?php
+									$update_type_value = get_field('exam_update_type');
+									$update_type_label = '';
+									$field_object = get_field_object('field_exam_update_type');
+									if ($field_object && isset($field_object['choices'][$update_type_value])) {
+										$update_type_label = $field_object['choices'][$update_type_value];
+									}
+									if ($update_type_label): ?>
+										<span class="update-type"> | <strong><?php esc_html_e('Type:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($update_type_label); ?></span>
+									<?php endif; ?>
+								</div>
+                                <?php
+                                $summary = get_field('exam_update_summary');
+                                if ($summary) {
+                                    echo '<p class="exam-update-card-summary">' . wp_kses_post(wp_trim_words($summary, 25, '...')) . '</p>';
+                                } else {
+                                    the_excerpt(); // Fallback to standard excerpt if summary is empty
+                                }
+                                ?>
+								<a href="<?php the_permalink(); ?>" class="button exam-update-card-button"><?php esc_html_e('Read More', 'collegenexis-theme'); ?></a>
+							</div>
+						</div>
+					</article><!-- #post-<?php the_ID(); ?> -->
+					<?php
+				endwhile;
+				?>
+				</div> <!-- .exam-update-listings-list -->
+				<?php
+
+				the_posts_navigation();
+
+			else :
+
+				get_template_part( 'template-parts/content', 'none' );
+
+			endif;
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/archive-roadmap.php
+++ b/wp-content/themes/collegenexis-theme/archive-roadmap.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * The template for displaying archive pages for the Roadmap CPT
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php if ( have_posts() ) : ?>
+
+				<header class="page-header">
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<?php
+					<?php
+						the_archive_title( '<h1 class="page-title">', '</h1>' );
+						the_archive_description( '<div class="archive-description">', '</div>' );
+					?>
+				</header><!-- .page-header -->
+
+				<div class="roadmap-listings-list"> <?php // Changed to list, can be styled as grid too ?>
+				<?php
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+					?>
+					<article id="post-<?php the_ID(); ?>" <?php post_class('roadmap-card'); ?>>
+						<div class="roadmap-card-inner">
+							<div class="roadmap-card-content">
+								<?php the_title(sprintf('<h2 class="entry-title roadmap-card-title"><a href="%s" rel="bookmark">', esc_url(get_permalink())), '</a></h2>'); ?>
+
+								<?php
+								$introduction = get_field('roadmap_introduction');
+								if ($introduction) :
+									// Display a truncated version of the introduction
+									$excerpt = wp_trim_words(wp_strip_all_tags($introduction), 30, '...'); // Get 30 words
+									?>
+									<p class="roadmap-card-excerpt"><?php echo esc_html($excerpt); ?></p>
+								<?php elseif (has_excerpt()) : ?>
+                                    <p class="roadmap-card-excerpt"><?php the_excerpt(); ?></p>
+                                <?php endif; ?>
+
+								<a href="<?php the_permalink(); ?>" class="button roadmap-card-button"><?php esc_html_e('View Roadmap', 'collegenexis-theme'); ?></a>
+							</div>
+						</div>
+					</article><!-- #post-<?php the_ID(); ?> -->
+					<?php
+				endwhile;
+				?>
+				</div> <!-- .roadmap-listings-list -->
+				<?php
+
+				the_posts_navigation();
+
+			else :
+
+				get_template_part( 'template-parts/content', 'none' );
+
+			endif;
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/footer.php
+++ b/wp-content/themes/collegenexis-theme/footer.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * The template for displaying the footer
+ *
+ * Contains the closing of the #content div and all content after.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package College_Nexis_Theme
+ */
+
+?>
+		<!-- Content ends here -->
+	</div><!-- #content -->
+
+	<footer id="colophon" class="site-footer">
+		<div class="container">
+			<div class="site-info">
+				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'collegenexis-theme' ) ); ?>">
+					<?php
+					/* translators: %s: CMS name, i.e. WordPress. */
+					printf( esc_html__( 'Proudly powered by %s', 'collegenexis-theme' ), 'WordPress' );
+					?>
+				</a>
+				<span class="sep"> | </span>
+				<?php
+				/* translators: 1: Theme name, 2: Theme author. */
+				printf( esc_html__( 'Theme: %1$s by %2$s.', 'collegenexis-theme' ), 'College Nexis Theme', '<a href="https://collegenexis.com/">Manas Ranjan Bisi</a>' );
+				?>
+			</div><!-- .site-info -->
+			<div class="footer-menu">
+				<?php
+				if ( has_nav_menu( 'footer-menu' ) ) {
+					wp_nav_menu(
+						array(
+							'theme_location' => 'footer-menu',
+							'menu_id'        => 'footer-menu',
+							'depth'          => 1,
+						)
+					);
+				}
+				?>
+			</div>
+			<div class="copyright">
+				&copy; <?php echo date('Y'); ?> <?php bloginfo('name'); ?>. <?php esc_html_e('All Rights Reserved.', 'collegenexis-theme'); ?>
+			</div>
+		</div><!-- .container -->
+	</footer><!-- #colophon -->
+</div><!-- #page -->
+
+<?php wp_footer(); ?>
+
+</body>
+</html>

--- a/wp-content/themes/collegenexis-theme/front-page.php
+++ b/wp-content/themes/collegenexis-theme/front-page.php
@@ -1,0 +1,241 @@
+<?php
+/**
+ * The template for displaying the static front page.
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+
+		<?php
+		// Display content of the page set as Front Page in Settings > Reading
+		// This allows admins to add content above/below dynamic sections via the page editor.
+		while ( have_posts() ) :
+			the_post();
+			if (get_the_content()) { // Only display if there's content in the page editor
+				?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class('front-page-content'); ?>>
+					<div class="container">
+						<div class="entry-content">
+							<?php the_content(); ?>
+						</div><!-- .entry-content -->
+					</div><!-- .container -->
+				</article><!-- #post-<?php the_ID(); ?> -->
+				<?php
+			}
+		endwhile; // End of the loop.
+		?>
+
+		<!-- Hero Section -->
+		<section id="hero-section" class="front-page-section hero-section">
+			<div class="container">
+				<div class="hero-content-wrapper">
+					<div class="hero-image-or-illustration">
+						<!-- Placeholder for image/illustration - can be managed via Customizer or a dedicated options page -->
+						<img src="<?php echo get_template_directory_uri() . '/assets/images/hero-placeholder.png'; // Example placeholder ?>" alt="College Nexis Hero Image">
+					</div>
+					<div class="hero-text-and-search">
+						<h1 class="hero-tagline"><?php echo esc_html_e( 'Your Smart Companion to Discover, Plan, and Build Your Career.', 'collegenexis-theme' ); ?></h1>
+						<p class="hero-subtagline"><?php echo esc_html_e( 'Find the right college, the right course, stress-free.', 'collegenexis-theme' ); ?></p>
+						<div class="hero-search-form">
+							<?php get_search_form(); ?>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- Featured Colleges Section -->
+		<section id="featured-colleges-section" class="front-page-section featured-colleges">
+			<div class="container">
+				<h2 class="section-title"><?php esc_html_e('Featured Colleges', 'collegenexis-theme'); ?></h2>
+				<?php
+				$featured_colleges_args = array(
+					'post_type' => 'college',
+					'posts_per_page' => 4, // Adjust number as needed
+					'meta_query' => array(
+						array(
+							'key' => 'college_is_featured',
+							'value' => '1',
+							'compare' => '=',
+						),
+					),
+					'no_found_rows' => true, // Optimization
+				);
+				$featured_colleges_query = new WP_Query($featured_colleges_args);
+
+				if ($featured_colleges_query->have_posts()) :
+				?>
+					<div class="college-listings-grid featured-colleges-grid">
+						<?php
+						while ($featured_colleges_query->have_posts()) : $featured_colleges_query->the_post();
+							// Using the same card structure as archive-college.php for consistency
+							// You might want to create a dedicated template part: get_template_part('template-parts/content', 'college-card');
+							?>
+							<article id="post-<?php the_ID(); ?>" <?php post_class('college-card'); ?>>
+								<div class="college-card-inner">
+									<?php
+									$logo_image = get_field('college_logo_image');
+									if ($logo_image && isset($logo_image['sizes']['medium'])) : ?>
+										<div class="college-card-logo">
+											<a href="<?php the_permalink(); ?>">
+												<img src="<?php echo esc_url($logo_image['sizes']['medium']); ?>" alt="<?php echo esc_attr($logo_image['alt'] ?: get_the_title() . ' Logo'); ?>">
+											</a>
+										</div>
+									<?php elseif (has_post_thumbnail()) : ?>
+										<div class="college-card-logo">
+											<a href="<?php the_permalink(); ?>">
+												<?php the_post_thumbnail('medium'); ?>
+											</a>
+										</div>
+									<?php endif; ?>
+									<div class="college-card-content">
+										<?php the_title(sprintf('<h3 class="entry-title college-card-title"><a href="%s" rel="bookmark">', esc_url(get_permalink())), '</a></h3>'); ?>
+										<?php
+										$city = get_field('college_city');
+										$state = get_field('college_state');
+										if ($city || $state) : ?>
+											<p class="college-card-location">
+												<?php if ($city) echo esc_html($city); ?><?php if ($city && $state) echo ', '; ?><?php if ($state) echo esc_html($state); ?>
+											</p>
+										<?php endif; ?>
+										<a href="<?php the_permalink(); ?>" class="button college-card-button"><?php esc_html_e('View Details', 'collegenexis-theme'); ?></a>
+									</div>
+								</div>
+							</article>
+						<?php endwhile; ?>
+					</div>
+				<?php
+				wp_reset_postdata(); // Important after custom WP_Query
+				else :
+					echo '<p>' . esc_html__('No featured colleges available at the moment.', 'collegenexis-theme') . '</p>';
+				endif;
+				?>
+			</div>
+		</section>
+
+		<!-- Browse by Course Category Section -->
+		<section id="course-categories-section" class="front-page-section course-categories">
+			<div class="container">
+				<h2 class="section-title"><?php esc_html_e('Browse by Course Category', 'collegenexis-theme'); ?></h2>
+				<?php
+				$course_categories = get_terms(array(
+					'taxonomy' => 'course_category',
+					'hide_empty' => true, // Set to false if you want to show empty categories
+					'orderby' => 'name',
+					'order' => 'ASC',
+				));
+				if (!empty($course_categories) && !is_wp_error($course_categories)) :
+				?>
+					<ul class="course-category-list">
+						<?php foreach ($course_categories as $category) : ?>
+							<li class="course-category-item">
+								<a href="<?php echo esc_url(get_term_link($category)); ?>">
+									<?php // You could add an ACF image field to the taxonomy for icons here ?>
+									<span class="category-name"><?php echo esc_html($category->name); ?></span>
+									<span class="category-count">(<?php echo esc_html($category->count); ?> <?php esc_html_e('Courses', 'collegenexis-theme'); ?>)</span>
+								</a>
+							</li>
+						<?php endforeach; ?>
+					</ul>
+				<?php else : ?>
+					<p><?php esc_html_e('No course categories found.', 'collegenexis-theme'); ?></p>
+				<?php endif; ?>
+			</div>
+		</section>
+
+		<!-- Latest Blog Posts Section -->
+		<section id="latest-blog-posts-section" class="front-page-section latest-posts">
+			<div class="container">
+				<h2 class="section-title"><?php esc_html_e('From Our Blog', 'collegenexis-theme'); ?></h2>
+				<?php
+				$latest_posts_args = array(
+					'post_type' => 'post',
+					'posts_per_page' => 3, // Adjust number as needed
+					'ignore_sticky_posts' => 1,
+					'no_found_rows' => true,
+				);
+				$latest_posts_query = new WP_Query($latest_posts_args);
+				if ($latest_posts_query->have_posts()) :
+				?>
+					<div class="post-listings-grid latest-blog-grid">
+						<?php
+						while ($latest_posts_query->have_posts()) : $latest_posts_query->the_post();
+							// Using a simplified card for blog posts
+						?>
+							<article id="post-<?php the_ID(); ?>" <?php post_class('post-card'); ?>>
+								<div class="post-card-inner">
+									<?php if (has_post_thumbnail()) : ?>
+										<div class="post-card-thumbnail">
+											<a href="<?php the_permalink(); ?>">
+												<?php the_post_thumbnail('medium_large'); // Or another appropriate size ?>
+											</a>
+										</div>
+									<?php endif; ?>
+									<div class="post-card-content">
+										<?php the_title(sprintf('<h3 class="entry-title post-card-title"><a href="%s" rel="bookmark">', esc_url(get_permalink())), '</a></h3>'); ?>
+										<div class="post-card-excerpt">
+											<?php the_excerpt(); ?>
+										</div>
+										<a href="<?php the_permalink(); ?>" class="button post-card-button"><?php esc_html_e('Read More', 'collegenexis-theme'); ?></a>
+									</div>
+								</div>
+							</article>
+						<?php endwhile; ?>
+					</div>
+				<?php
+				wp_reset_postdata();
+				else :
+					echo '<p>' . esc_html__('No blog posts available yet.', 'collegenexis-theme') . '</p>';
+				endif;
+				?>
+			</div>
+		</section>
+
+		<!-- Latest Exam Updates Section -->
+		<section id="latest-exam-updates-section" class="front-page-section latest-exam-updates">
+			<div class="container">
+				<h2 class="section-title"><?php esc_html_e('Latest Exam Updates', 'collegenexis-theme'); ?></h2>
+				<?php
+				$latest_exams_args = array(
+					'post_type' => 'exam_update',
+					'posts_per_page' => 5, // Adjust number as needed
+					'orderby' => 'date', // Or 'meta_value_num' if sorting by 'exam_update_date'
+					// 'meta_key' => 'exam_update_date', // if sorting by this ACF field
+					'order' => 'DESC',
+					'no_found_rows' => true,
+				);
+				$latest_exams_query = new WP_Query($latest_exams_args);
+				if ($latest_exams_query->have_posts()) :
+				?>
+					<ul class="exam-update-list">
+						<?php
+						while ($latest_exams_query->have_posts()) : $latest_exams_query->the_post();
+						?>
+							<li class="exam-update-list-item">
+								<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+								<?php
+								$key_date = get_field('exam_update_date');
+								if ($key_date): ?>
+									<span class="exam-date-meta"> - <?php echo esc_html(date_i18n(get_option('date_format'), strtotime($key_date))); ?></span>
+								<?php endif; ?>
+							</li>
+						<?php endwhile; ?>
+					</ul>
+				<?php
+				wp_reset_postdata();
+				else :
+					echo '<p>' . esc_html__('No exam updates posted recently.', 'collegenexis-theme') . '</p>';
+				endif;
+				?>
+			</div>
+		</section>
+
+	</main><!-- #main -->
+
+<?php
+get_footer();
+?>

--- a/wp-content/themes/collegenexis-theme/functions.php
+++ b/wp-content/themes/collegenexis-theme/functions.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * College Nexis Theme functions and definitions
+ *
+ * @link https://developer.wordpress.org/themes/basics/theme-functions/
+ *
+ * @package College_Nexis_Theme
+ */
+
+if ( ! defined( 'COLLEGE_NEXIS_THEME_VERSION' ) ) {
+	// Replace the version number of the theme on each release.
+	define( 'COLLEGE_NEXIS_THEME_VERSION', '1.0.0' );
+}
+
+if ( ! function_exists( 'collegenexis_theme_setup' ) ) :
+	/**
+	 * Sets up theme defaults and registers support for various WordPress features.
+	 *
+	 * Note that this function is hooked into the after_setup_theme hook, which
+	 * runs before the init hook. The init hook is too late for some features, such
+	 * as indicating support for post thumbnails.
+	 */
+	function collegenexis_theme_setup() {
+		/*
+		 * Make theme available for translation.
+		 * Translations can be filed in the /languages/ directory.
+		 * If you're building a theme based on College Nexis Theme, use a find and replace
+		 * to change 'collegenexis-theme' to the name of your theme in all the template files.
+		 */
+		load_theme_textdomain( 'collegenexis-theme', get_template_directory() . '/languages' );
+
+		// Add default posts and comments RSS feed links to head.
+		add_theme_support( 'automatic-feed-links' );
+
+		/*
+		 * Let WordPress manage the document title.
+		 * By adding theme support, we declare that this theme does not use a
+		 * hard-coded <title> tag in the document head, and expect WordPress to
+		 * provide it for us.
+		 */
+		add_theme_support( 'title-tag' );
+
+		/*
+		 * Enable support for Post Thumbnails on posts and pages.
+		 *
+		 * @link https://developer.wordpress.org/themes/functionality/featured-images-post-thumbnails/
+		 */
+		add_theme_support( 'post-thumbnails' );
+
+		// This theme uses wp_nav_menu() in one location.
+		register_nav_menus(
+			array(
+				'menu-1' => esc_html__( 'Primary Menu', 'collegenexis-theme' ),
+				'footer-menu' => esc_html__( 'Footer Menu', 'collegenexis-theme' ),
+			)
+		);
+
+		/*
+		 * Switch default core markup for search form, comment form, and comments
+		 * to output valid HTML5.
+		 */
+		add_theme_support(
+			'html5',
+			array(
+				'search-form',
+				'comment-form',
+				'comment-list',
+				'gallery',
+				'caption',
+				'style',
+				'script',
+			)
+		);
+
+		// Set up the WordPress core custom background feature.
+		add_theme_support(
+			'custom-background',
+			apply_filters(
+				'collegenexis_theme_custom_background_args',
+				array(
+					'default-color' => 'ffffff',
+					'default-image' => '',
+				)
+			)
+		);
+
+		// Add theme support for selective refresh for widgets.
+		add_theme_support( 'customize-selective-refresh-widgets' );
+
+		/**
+		 * Add support for core custom logo.
+		 *
+		 * @link https://codex.wordpress.org/Theme_Logo
+		 */
+		add_theme_support(
+			'custom-logo',
+			array(
+				'height'      => 250,
+				'width'       => 250,
+				'flex-width'  => true,
+				'flex-height' => true,
+			)
+		);
+
+		// Add support for editor styles.
+        add_theme_support( 'editor-styles' );
+
+        // Enqueue editor styles.
+        add_editor_style( 'style-editor.css' ); // You would create this file for block editor specific styles
+
+		// Add support for responsive embedded content.
+        add_theme_support( 'responsive-embeds' );
+
+		// Add support for block styles.
+		add_theme_support( 'wp-block-styles' );
+
+	}
+endif;
+add_action( 'after_setup_theme', 'collegenexis_theme_setup' );
+
+/**
+ * Set the content width in pixels, based on the theme's design and stylesheet.
+ *
+ * Priority 0 to make it available to lower priority callbacks.
+ *
+ * @global int $content_width
+ */
+function collegenexis_theme_content_width() {
+	// This variable is intended to be overruled from themes.
+	// Open WPCS issue: {@link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/1043}.
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+	$GLOBALS['content_width'] = apply_filters( 'collegenexis_theme_content_width', 640 );
+}
+add_action( 'after_setup_theme', 'collegenexis_theme_content_width', 0 );
+
+/**
+ * Enqueue scripts and styles.
+ */
+function collegenexis_theme_scripts() {
+	wp_enqueue_style( 'collegenexis-theme-style', get_stylesheet_uri(), array(), COLLEGE_NEXIS_THEME_VERSION );
+	// wp_style_add_data( 'collegenexis-theme-style', 'rtl', 'replace' ); // If supporting RTL
+
+	// You can enqueue more styles or scripts here
+	// Example: wp_enqueue_style( 'collegenexis-theme-google-fonts', 'YOUR_GOOGLE_FONTS_URL', array(), null );
+	// Example: wp_enqueue_script( 'collegenexis-theme-navigation', get_template_directory_uri() . '/js/navigation.js', array(), COLLEGE_NEXIS_THEME_VERSION, true );
+
+	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
+		wp_enqueue_script( 'comment-reply' );
+	}
+}
+add_action( 'wp_enqueue_scripts', 'collegenexis_theme_scripts' );
+
+/**
+ * Implement the Custom Header feature.
+ */
+// require get_template_directory() . '/inc/custom-header.php'; // Example if you add custom header features
+
+/**
+ * Custom template tags for this theme.
+ */
+require get_template_directory() . '/inc/template-tags.php';
+
+/**
+ * Functions which enhance the theme by hooking into WordPress.
+ */
+require get_template_directory() . '/inc/template-functions.php';
+
+/**
+ * Customizer additions.
+ */
+require get_template_directory() . '/inc/customizer.php';
+
+/**
+ * Load Jetpack compatibility file.
+ */
+// if ( defined( 'JETPACK__VERSION' ) ) { // Example if you add Jetpack support
+// 	require get_template_directory() . '/inc/jetpack.php';
+// }
+
+/**
+ * Load WooCommerce compatibility file.
+ */
+// if ( class_exists( 'WooCommerce' ) ) { // Example if you add WooCommerce support
+// 	require get_template_directory() . '/inc/woocommerce.php';
+// }
+
+?>

--- a/wp-content/themes/collegenexis-theme/header.php
+++ b/wp-content/themes/collegenexis-theme/header.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * The header for our theme
+ *
+ * This is the template that displays all of the <head> section and everything up until <div id="content">
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-files/#template-partials
+ *
+ * @package College_Nexis_Theme
+ */
+
+?>
+<!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="profile" href="https://gmpg.org/xfn/11">
+
+	<?php wp_head(); ?>
+</head>
+
+<body <?php body_class(); ?>>
+<?php wp_body_open(); ?>
+<div id="page" class="site">
+	<a class="skip-link screen-reader-text" href="#primary"><?php esc_html_e( 'Skip to content', 'collegenexis-theme' ); ?></a>
+
+	<header id="masthead" class="site-header">
+		<div class="container">
+			<div class="site-branding">
+				<?php
+				if ( has_custom_logo() ) {
+					the_custom_logo();
+				} elseif ( is_front_page() && is_home() ) {
+					?>
+					<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+					<?php
+				} else {
+					?>
+					<p class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></p>
+					<?php
+				}
+				$collegenexis_theme_description = get_bloginfo( 'description', 'display' );
+				if ( $collegenexis_theme_description || is_customize_preview() ) :
+					?>
+					<p class="site-description"><?php echo $collegenexis_theme_description; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
+				<?php endif; ?>
+			</div><!-- .site-branding -->
+
+			<nav id="site-navigation" class="main-navigation">
+				<button class="menu-toggle" aria-controls="primary-menu" aria-expanded="false"><?php esc_html_e( 'Primary Menu', 'collegenexis-theme' ); ?></button>
+				<?php
+				wp_nav_menu(
+					array(
+						'theme_location' => 'menu-1',
+						'menu_id'        => 'primary-menu',
+						'fallback_cb'    => false, // Do not fall back to wp_page_menu()
+					)
+				);
+				?>
+			</nav><!-- #site-navigation -->
+		</div><!-- .container -->
+	</header><!-- #masthead -->
+
+	<div id="content" class="site-content">
+		<!-- Content starts here -->

--- a/wp-content/themes/collegenexis-theme/inc/customizer.php
+++ b/wp-content/themes/collegenexis-theme/inc/customizer.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * College Nexis Theme Customizer
+ *
+ * @package College_Nexis_Theme
+ */
+
+/**
+ * Add postMessage support for site title and description for the Theme Customizer.
+ *
+ * @param WP_Customize_Manager $wp_customize Theme Customizer object.
+ */
+function collegenexis_theme_customize_register( $wp_customize ) {
+	$wp_customize->get_setting( 'blogname' )->transport         = 'postMessage';
+	$wp_customize->get_setting( 'blogdescription' )->transport  = 'postMessage';
+	// $wp_customize->get_setting( 'header_textcolor' )->transport = 'postMessage'; // If using this
+
+	if ( isset( $wp_customize->selective_refresh ) ) {
+		$wp_customize->selective_refresh->add_partial(
+			'blogname',
+			array(
+				'selector'        => '.site-title a',
+				'render_callback' => 'collegenexis_theme_customize_partial_blogname',
+			)
+		);
+		$wp_customize->selective_refresh->add_partial(
+			'blogdescription',
+			array(
+				'selector'        => '.site-description',
+				'render_callback' => 'collegenexis_theme_customize_partial_blogdescription',
+			)
+		);
+	}
+
+	// Theme Options Panel
+	$wp_customize->add_panel('collegenexis_theme_options_panel', array(
+        'title' => __('College Nexis Options', 'collegenexis-theme'),
+        'priority' => 10, // Adjust priority as needed
+        'capability' => 'edit_theme_options',
+    ));
+
+    // Colors Section
+    $wp_customize->add_section('collegenexis_colors_section', array(
+        'title' => __('Color Scheme', 'collegenexis-theme'),
+        'panel' => 'collegenexis_theme_options_panel',
+        'priority' => 10,
+    ));
+
+    // Primary Color Setting
+    $wp_customize->add_setting('collegenexis_primary_color', array(
+        'default' => '#0050A0', // Deep Blue
+        'sanitize_callback' => 'sanitize_hex_color',
+        'transport' => 'refresh', // or 'postMessage' with JS handling
+    ));
+    $wp_customize->add_control(new WP_Customize_Color_Control($wp_customize, 'collegenexis_primary_color_control', array(
+        'label' => __('Primary Color', 'collegenexis-theme'),
+        'section' => 'collegenexis_colors_section',
+        'settings' => 'collegenexis_primary_color',
+    )));
+
+    // Accent Color Setting
+    $wp_customize->add_setting('collegenexis_accent_color', array(
+        'default' => '#FFD700', // Gold
+        'sanitize_callback' => 'sanitize_hex_color',
+        'transport' => 'refresh',
+    ));
+    $wp_customize->add_control(new WP_Customize_Color_Control($wp_customize, 'collegenexis_accent_color_control', array(
+        'label' => __('Accent Color', 'collegenexis-theme'),
+        'section' => 'collegenexis_colors_section',
+        'settings' => 'collegenexis_accent_color',
+    )));
+
+    // Fonts Section
+    $wp_customize->add_section('collegenexis_fonts_section', array(
+        'title' => __('Typography', 'collegenexis-theme'),
+        'panel' => 'collegenexis_theme_options_panel',
+        'priority' => 20,
+    ));
+
+    // Heading Font Setting
+    $wp_customize->add_setting('collegenexis_heading_font', array(
+        'default' => 'Montserrat',
+        'sanitize_callback' => 'collegenexis_sanitize_font_choice',
+        'transport' => 'refresh',
+    ));
+    $wp_customize->add_control('collegenexis_heading_font_control', array(
+        'label' => __('Heading Font', 'collegenexis-theme'),
+        'section' => 'collegenexis_fonts_section',
+        'settings' => 'collegenexis_heading_font',
+        'type' => 'select',
+        'choices' => array(
+            'Montserrat' => 'Montserrat',
+            'Lato' => 'Lato',
+            'Open Sans' => 'Open Sans',
+            'Roboto' => 'Roboto',
+            'Nunito' => 'Nunito',
+            'Poppins' => 'Poppins',
+            'Merriweather' => 'Merriweather', // A serif option
+        ),
+    ));
+
+    // Body Font Setting
+    $wp_customize->add_setting('collegenexis_body_font', array(
+        'default' => 'Lato',
+        'sanitize_callback' => 'collegenexis_sanitize_font_choice',
+        'transport' => 'refresh',
+    ));
+    $wp_customize->add_control('collegenexis_body_font_control', array(
+        'label' => __('Body Font', 'collegenexis-theme'),
+        'section' => 'collegenexis_fonts_section',
+        'settings' => 'collegenexis_body_font',
+        'type' => 'select',
+        'choices' => array(
+            'Lato' => 'Lato',
+            'Open Sans' => 'Open Sans',
+            'Roboto' => 'Roboto',
+            'Nunito' => 'Nunito',
+            'Montserrat' => 'Montserrat',
+            'Source Sans Pro' => 'Source Sans Pro',
+            'Merriweather' => 'Merriweather',
+        ),
+    ));
+
+}
+add_action( 'customize_register', 'collegenexis_theme_customize_register' );
+
+/**
+ * Sanitize font choice.
+ *
+ * @param string $input The input font.
+ * @return string Sanitized font choice.
+ */
+function collegenexis_sanitize_font_choice( $input ) {
+    $valid_fonts = array(
+        'Montserrat', 'Lato', 'Open Sans', 'Roboto', 'Nunito', 'Poppins', 'Merriweather', 'Source Sans Pro'
+    );
+    if ( in_array( $input, $valid_fonts, true ) ) {
+        return $input;
+    }
+    return 'Lato'; // Default fallback
+}
+
+
+/**
+ * Render the site title for the selective refresh partial.
+ *
+ * @return void
+ */
+function collegenexis_theme_customize_partial_blogname() {
+	bloginfo( 'name' );
+}
+
+/**
+ * Render the site tagline for the selective refresh partial.
+ *
+ * @return void
+ */
+function collegenexis_theme_customize_partial_blogdescription() {
+	bloginfo( 'description' );
+}
+
+/**
+ * Binds JS handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+function collegenexis_theme_customize_preview_js() {
+	wp_enqueue_script( 'collegenexis-theme-customizer', get_template_directory_uri() . '/js/customizer.js', array( 'customize-preview' ), COLLEGE_NEXIS_THEME_VERSION, true );
+}
+add_action( 'customize_preview_init', 'collegenexis_theme_customize_preview_js' );
+
+
+/**
+ * Enqueue Google Fonts and output CSS for customizer options.
+ */
+function collegenexis_theme_customizer_css() {
+    $primary_color = get_theme_mod( 'collegenexis_primary_color', '#0050A0' );
+    $accent_color = get_theme_mod( 'collegenexis_accent_color', '#FFD700' );
+    $heading_font = get_theme_mod( 'collegenexis_heading_font', 'Montserrat' );
+    $body_font = get_theme_mod( 'collegenexis_body_font', 'Lato' );
+
+    // Enqueue Google Fonts
+    $font_families = array();
+    if ( $heading_font && $heading_font !== 'System Default' ) $font_families[] = $heading_font . ':400,700'; // Weights
+    if ( $body_font && $body_font !== 'System Default' ) $font_families[] = $body_font . ':400,400i,700'; // Weights
+
+    if ( count( $font_families ) > 0 ) {
+        $query_args = array(
+            'family' => urlencode( implode( '|', array_unique( $font_families ) ) ),
+            'subset' => urlencode( 'latin,latin-ext' ), // Adjust as needed
+            'display' => 'swap',
+        );
+        $fonts_url = add_query_arg( $query_args, 'https://fonts.googleapis.com/css' );
+        wp_enqueue_style( 'collegenexis-theme-google-fonts', $fonts_url, array(), null );
+    }
+
+    // Customizer CSS
+    $custom_css = "
+        :root {
+            --cn-primary-color: {$primary_color};
+            --cn-accent-color: {$accent_color};
+            --cn-heading-font: '{$heading_font}', sans-serif;
+            --cn-body-font: '{$body_font}', sans-serif;
+        }
+
+        body {
+            font-family: var(--cn-body-font);
+            color: #333; /* Example body text color */
+        }
+        h1, h2, h3, h4, h5, h6 {
+            font-family: var(--cn-heading-font);
+            color: var(--cn-primary-color); /* Example: Headings use primary color */
+        }
+        a {
+            color: var(--cn-primary-color);
+        }
+        a:hover, a:focus {
+            color: var(--cn-accent-color);
+        }
+
+        /* Example usage of accent color */
+        button, input[type='submit'], .button, .wp-block-button__link {
+            background-color: var(--cn-primary-color);
+            color: #fff;
+            border: 1px solid var(--cn-primary-color);
+        }
+        button:hover, input[type='submit']:hover, .button:hover, .wp-block-button__link:hover {
+            background-color: var(--cn-accent-color);
+            border-color: var(--cn-accent-color);
+            color: #333;
+        }
+
+        /* Specific theme elements */
+        .site-header {
+             /* background-color: var(--cn-primary-color); Example */
+             /* color: #fff; */
+        }
+        .site-title a {
+            /* color: #fff; */
+        }
+        .main-navigation a {
+            /* color: #fff; */
+        }
+        .main-navigation a:hover {
+            /* color: var(--cn-accent-color); */
+        }
+
+        /* Add more specific rules as needed */
+    ";
+    wp_add_inline_style( 'collegenexis-theme-style', $custom_css ); // Enqueue after main stylesheet
+}
+add_action( 'wp_enqueue_scripts', 'collegenexis_theme_customizer_css' );

--- a/wp-content/themes/collegenexis-theme/inc/template-functions.php
+++ b/wp-content/themes/collegenexis-theme/inc/template-functions.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Functions which enhance the theme by hooking into WordPress
+ *
+ * @package College_Nexis_Theme
+ */
+
+/**
+ * Adds custom classes to the array of body classes.
+ *
+ * @param array $classes Classes for the body element.
+ * @return array
+ */
+function collegenexis_theme_body_classes( $classes ) {
+	// Adds a class of hfeed to non-singular pages.
+	if ( ! is_singular() ) {
+		$classes[] = 'hfeed';
+	}
+
+	// Adds a class of no-sidebar when there is no sidebar present.
+	if ( ! is_active_sidebar( 'sidebar-1' ) ) { // Assuming a sidebar named 'sidebar-1'
+		$classes[] = 'no-sidebar';
+	}
+
+	return $classes;
+}
+add_filter( 'body_class', 'collegenexis_theme_body_classes' );
+
+/**
+ * Add a pingback url auto-discovery header for single posts, pages, or attachments.
+ */
+function collegenexis_theme_pingback_header() {
+	if ( is_singular() && pings_open() ) {
+		printf( '<link rel="pingback" href="%s">', esc_url( get_bloginfo( 'pingback_url' ) ) );
+	}
+}
+add_action( 'wp_head', 'collegenexis_theme_pingback_header' );
+
+// More theme-enhancing functions can be added here.

--- a/wp-content/themes/collegenexis-theme/inc/template-tags.php
+++ b/wp-content/themes/collegenexis-theme/inc/template-tags.php
@@ -1,0 +1,156 @@
+<?php
+/**
+ * Custom template tags for this theme
+ *
+ * Eventually, some of the functionality here could be replaced by core features.
+ *
+ * @package College_Nexis_Theme
+ */
+
+if ( ! function_exists( 'collegenexis_theme_posted_on' ) ) :
+	/**
+	 * Prints HTML with meta information for the current post-date/time.
+	 */
+	function collegenexis_theme_posted_on() {
+		$time_string = '<time class="entry-date published updated" datetime="%1$s">%2$s</time>';
+		if ( get_the_time( 'U' ) !== get_the_modified_time( 'U' ) ) {
+			$time_string = '<time class="entry-date published" datetime="%1$s">%2$s</time><time class="updated" datetime="%3$s">%4$s</time>';
+		}
+
+		$time_string = sprintf(
+			$time_string,
+			esc_attr( get_the_date( DATE_W3C ) ),
+			esc_html( get_the_date() ),
+			esc_attr( get_the_modified_date( DATE_W3C ) ),
+			esc_html( get_the_modified_date() )
+		);
+
+		$posted_on = sprintf(
+			/* translators: %s: post date. */
+			esc_html_x( 'Posted on %s', 'post date', 'collegenexis-theme' ),
+			'<a href="' . esc_url( get_permalink() ) . '" rel="bookmark">' . $time_string . '</a>'
+		);
+
+		echo '<span class="posted-on">' . $posted_on . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+if ( ! function_exists( 'collegenexis_theme_entry_footer' ) ) :
+	/**
+	 * Prints HTML with meta information for the categories, tags and comments.
+	 */
+	function collegenexis_theme_entry_footer() {
+		// Hide category and tag text for pages.
+		if ( 'post' === get_post_type() ) {
+			/* translators: used between list items, there is a space after the comma */
+			$categories_list = get_the_category_list( esc_html__( ', ', 'collegenexis-theme' ) );
+			if ( $categories_list ) {
+				/* translators: 1: list of categories. */
+				printf( '<span class="cat-links">' . esc_html__( 'Posted in %1$s', 'collegenexis-theme' ) . '</span>', $categories_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+
+			/* translators: used between list items, there is a space after the comma */
+			$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'list item separator', 'collegenexis-theme' ) );
+			if ( $tags_list ) {
+				/* translators: 1: list of tags. */
+				printf( '<span class="tags-links">' . esc_html__( 'Tagged %1$s', 'collegenexis-theme' ) . '</span>', $tags_list ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+			}
+		}
+
+		if ( ! is_single() && ! post_password_required() && ( comments_open() || get_comments_number() ) ) {
+			echo '<span class="comments-link">';
+			comments_popup_link(
+				sprintf(
+					wp_kses(
+						/* translators: %s: post title */
+						__( 'Leave a Comment<span class="screen-reader-text"> on %s</span>', 'collegenexis-theme' ),
+						array(
+							'span' => array(
+								'class' => array(),
+							),
+						)
+					),
+					wp_kses_post( get_the_title() )
+				)
+			);
+			echo '</span>';
+		}
+
+		edit_post_link(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Edit <span class="screen-reader-text">%s</span>', 'collegenexis-theme' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				wp_kses_post( get_the_title() )
+			),
+			'<span class="edit-link">',
+			'</span>'
+		);
+	}
+endif;
+
+if ( ! function_exists( 'collegenexis_theme_post_thumbnail' ) ) :
+	/**
+	 * Displays an optional post thumbnail.
+	 *
+	 * Wraps the post thumbnail in an anchor element on index views, or a div
+	 * element on single views.
+	 */
+	function collegenexis_theme_post_thumbnail() {
+		if ( post_password_required() || is_attachment() || ! has_post_thumbnail() ) {
+			return;
+		}
+
+		if ( is_singular() ) :
+			?>
+
+			<div class="post-thumbnail">
+				<?php the_post_thumbnail(); ?>
+			</div><!-- .post-thumbnail -->
+
+		<?php else : ?>
+
+			<a class="post-thumbnail" href="<?php the_permalink(); ?>" aria-hidden="true" tabindex="-1">
+				<?php
+					the_post_thumbnail(
+						'post-thumbnail',
+						array(
+							'alt' => the_title_attribute(
+								array(
+									'echo' => false,
+								)
+							),
+						)
+					);
+				?>
+			</a>
+
+			<?php
+		endif; // End is_singular().
+	}
+endif;
+
+if ( ! function_exists( 'collegenexis_theme_posted_by' ) ) :
+	/**
+	 * Prints HTML with meta information for the current author.
+	 */
+	function collegenexis_theme_posted_by() {
+		$byline = sprintf(
+			/* translators: %s: post author. */
+			esc_html_x( 'by %s', 'post author', 'collegenexis-theme' ),
+			'<span class="author vcard"><a class="url fn n" href="' . esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ) . '">' . esc_html( get_the_author() ) . '</a></span>'
+		);
+
+		echo '<span class="byline"> ' . $byline . '</span>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+
+	}
+endif;
+
+// More template tags can be added here.

--- a/wp-content/themes/collegenexis-theme/index.php
+++ b/wp-content/themes/collegenexis-theme/index.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * The main template file
+ *
+ * This is the most generic template file in a WordPress theme
+ * and one of the two required files for a theme (the other being style.css).
+ * It is used to display a page when nothing more specific matches a query.
+ * E.g., it puts together the home page when no home.php file exists.
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+
+			<?php
+			if ( have_posts() ) :
+
+				if ( is_home() && ! is_front_page() ) :
+					?>
+					<header>
+						<h1 class="page-title screen-reader-text"><?php single_post_title(); ?></h1>
+					</header>
+					<?php
+				endif;
+
+				/* Start the Loop */
+				while ( have_posts() ) :
+					the_post();
+
+					/*
+					 * Include the Post-Type-specific template for the content.
+					 * If you want to override this in a child theme, then include a file
+					 * called content-___.php (where ___ is the Post Type name) and that will be used instead.
+					 */
+					get_template_part( 'template-parts/content', get_post_type() );
+
+				endwhile;
+
+				the_posts_navigation();
+
+			else :
+
+				get_template_part( 'template-parts/content', 'none' );
+
+			endif;
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/js/customizer.js
+++ b/wp-content/themes/collegenexis-theme/js/customizer.js
@@ -1,0 +1,76 @@
+/**
+ * File customizer.js.
+ *
+ * Theme Customizer enhancements for a better user experience.
+ *
+ * Contains handlers to make Theme Customizer preview reload changes asynchronously.
+ */
+
+( function( $ ) {
+
+	// Site title and description.
+	wp.customize( 'blogname', function( value ) {
+		value.bind( function( to ) {
+			$( '.site-title a' ).text( to );
+		} );
+	} );
+	wp.customize( 'blogdescription', function( value ) {
+		value.bind( function( to ) {
+			$( '.site-description' ).text( to );
+		} );
+	} );
+
+	// Header text color (if you were using it).
+	// wp.customize( 'header_textcolor', function( value ) {
+	// 	value.bind( function( to ) {
+	// 		if ( 'blank' === to ) {
+	// 			$( '.site-title a, .site-description' ).css( {
+	// 				'clip': 'rect(1px, 1px, 1px, 1px)',
+	// 				'position': 'absolute'
+	// 			} );
+	// 		} else {
+	// 			$( '.site-title a, .site-description' ).css( {
+	// 				'clip': 'auto',
+	// 				'position': 'relative'
+	// 			} );
+	// 			$( '.site-title a, .site-description' ).css( { // Or just .site-title a, .site-description if they share color
+	// 				'color': to
+	// 			} );
+	// 		}
+	// 	} );
+	// } );
+
+    // Example for Primary Color (if transport is postMessage)
+    // wp.customize( 'collegenexis_primary_color', function( value ) {
+    //     value.bind( function( newval ) {
+    //         // Update CSS custom property or directly style elements
+    //         document.documentElement.style.setProperty('--cn-primary-color', newval);
+    //         // Example direct styling (less ideal than CSS variables)
+    //         // $( 'a' ).css( 'color', newval );
+    //     } );
+    // } );
+
+    // Example for Accent Color (if transport is postMessage)
+    // wp.customize( 'collegenexis_accent_color', function( value ) {
+    //     value.bind( function( newval ) {
+    //         document.documentElement.style.setProperty('--cn-accent-color', newval);
+    //         // Example direct styling
+    //         // $( 'button' ).css( 'background-color', newval );
+    //     } );
+    // } );
+
+    // Example for Font Changes (if transport is postMessage)
+    // This is more complex as it might involve loading new font files or updating font stacks.
+    // Typically, for font changes, 'refresh' is simpler unless you build a more sophisticated preview system.
+    // wp.customize( 'collegenexis_heading_font', function( value ) {
+    //     value.bind( function( newval ) {
+    //         document.documentElement.style.setProperty('--cn-heading-font', newval + ', sans-serif');
+    //     } );
+    // } );
+    // wp.customize( 'collegenexis_body_font', function( value ) {
+    //     value.bind( function( newval ) {
+    //         document.documentElement.style.setProperty('--cn-body-font', newval + ', sans-serif');
+    //     } );
+    // } );
+
+} )( jQuery );

--- a/wp-content/themes/collegenexis-theme/single-college.php
+++ b/wp-content/themes/collegenexis-theme/single-college.php
@@ -1,0 +1,231 @@
+<?php
+/**
+ * The template for displaying all single College posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/#single-post
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php
+			while ( have_posts() ) :
+				the_post();
+
+				the_post();
+				?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class('college-profile'); ?>>
+					<header class="entry-header college-header">
+						<?php
+						// Display Hero Image if available
+						$hero_image = get_field('college_hero_image');
+						if ($hero_image && isset($hero_image['url'])) :
+							?>
+							<div class="college-hero-banner" style="background-image: url('<?php echo esc_url($hero_image['url']); ?>');">
+								<?php /* You can add overlay content here if needed */ ?>
+							</div>
+						<?php endif; ?>
+
+						<div class="college-title-logo-wrapper">
+                            <?php
+                            // College Logo
+                            $logo_image = get_field('college_logo_image');
+                            if ($logo_image && isset($logo_image['url'])) :
+                                ?>
+                                <div class="college-logo">
+                                    <img src="<?php echo esc_url($logo_image['url']); ?>" alt="<?php echo esc_attr($logo_image['alt'] ?: get_the_title() . ' Logo'); ?>">
+                                </div>
+                            <?php elseif (has_post_thumbnail()) : ?>
+                                <div class="college-logo">
+                                    <?php the_post_thumbnail('medium'); ?>
+                                </div>
+                            <?php endif; ?>
+						    <?php the_title('<h1 class="entry-title college-name">', '</h1>'); ?>
+                        </div>
+                        <?php
+                        $city = get_field('college_city');
+                        $state = get_field('college_state');
+                        if ($city || $state) : ?>
+                            <p class="college-location-summary">
+                                <?php if ($city) echo esc_html($city); ?>
+                                <?php if ($city && $state) echo ', '; ?>
+                                <?php if ($state) echo esc_html($state); ?>
+                            </p>
+                        <?php endif; ?>
+					</header><!-- .entry-header -->
+
+					<div class="entry-content college-details-content">
+
+                        <?php // Main Post Content (Description)
+                        if (get_the_content()): ?>
+                        <section id="college-description" class="college-section">
+                            <h2><?php esc_html_e('About the College', 'collegenexis-theme'); ?></h2>
+                            <?php the_content(); ?>
+                        </section>
+                        <?php endif; ?>
+
+						<section id="college-overview" class="college-section">
+							<h2><?php esc_html_e('Overview', 'collegenexis-theme'); ?></h2>
+							<ul class="overview-details">
+								<?php if ($college_type_terms = get_the_terms(get_the_ID(), 'college_type')): ?>
+									<li><strong><?php esc_html_e('Category:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($college_type_terms[0]->name); ?></li>
+								<?php endif; ?>
+								<?php if ($est_year = get_field('college_establishment_year')): ?>
+									<li><strong><?php esc_html_e('Established:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($est_year); ?></li>
+								<?php endif; ?>
+								<?php if ($approved_by = get_field('college_approved_by')): ?>
+									<li><strong><?php esc_html_e('Approved By:', 'collegenexis-theme'); ?></strong> <?php echo nl2br(esc_html($approved_by)); ?></li>
+								<?php endif; ?>
+								<?php if ($affiliated_to = get_field('college_affiliated_university')): ?>
+									<li><strong><?php esc_html_e('Affiliated To:', 'collegenexis-theme'); ?></strong> <?php echo nl2br(esc_html($affiliated_to)); ?></li>
+								<?php endif; ?>
+							</ul>
+						</section>
+
+						<section id="college-address-contact" class="college-section">
+							<h2><?php esc_html_e('Address & Contact', 'collegenexis-theme'); ?></h2>
+							<?php if ($address = get_field('college_address_street')): ?>
+								<p><strong><?php esc_html_e('Address:', 'collegenexis-theme'); ?></strong><br><?php echo nl2br(esc_html($address)); ?>, <?php echo esc_html(get_field('college_city')); ?>, <?php echo esc_html(get_field('college_state')); ?> - <?php echo esc_html(get_field('college_pin_code')); ?></p>
+							<?php endif; ?>
+							<?php if ($phone = get_field('college_phone_number')): ?>
+								<p><strong><?php esc_html_e('Phone:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($phone); ?></p>
+							<?php endif; ?>
+							<?php if ($email = get_field('college_email')): ?>
+								<p><strong><?php esc_html_e('Email:', 'collegenexis-theme'); ?></strong> <a href="mailto:<?php echo esc_attr($email); ?>"><?php echo esc_html($email); ?></a></p>
+							<?php endif; ?>
+							<?php if ($website = get_field('college_website')): ?>
+								<p><strong><?php esc_html_e('Website:', 'collegenexis-theme'); ?></strong> <a href="<?php echo esc_url($website); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($website); ?></a></p>
+							<?php endif; ?>
+							<?php if ($map = get_field('college_google_map')): // ACF Pro field ?>
+								<div class="acf-map">
+									<div class="marker" data-lat="<?php echo esc_attr($map['lat']); ?>" data-lng="<?php echo esc_attr($map['lng']); ?>"></div>
+								</div>
+                                <p><small><?php esc_html_e('(Map functionality requires ACF Pro and Google Maps API setup)', 'collegenexis-theme'); ?></small></p>
+							<?php endif; ?>
+						</section>
+
+						<?php if (have_rows('college_courses_fees_structure')): ?>
+						<section id="college-courses-fees" class="college-section">
+							<h2><?php esc_html_e('Courses & Fee Structure', 'collegenexis-theme'); ?></h2>
+							<div class="courses-fees-table">
+								<table>
+									<thead>
+										<tr>
+											<th><?php esc_html_e('Course Name / Degree', 'collegenexis-theme'); ?></th>
+											<th><?php esc_html_e('Fee Details', 'collegenexis-theme'); ?></th>
+											<th><?php esc_html_e('Duration', 'collegenexis-theme'); ?></th>
+											<th><?php esc_html_e('Eligibility (Brief)', 'collegenexis-theme'); ?></th>
+										</tr>
+									</thead>
+									<tbody>
+									<?php while(have_rows('college_courses_fees_structure')): the_row(); ?>
+										<tr>
+											<td><?php echo esc_html(get_sub_field('course_name')); ?></td>
+											<td><?php echo esc_html(get_sub_field('fee_details')); ?></td>
+											<td><?php echo esc_html(get_sub_field('duration')); ?></td>
+											<td><?php echo esc_html(get_sub_field('eligibility_summary')); ?></td>
+										</tr>
+									<?php endwhile; ?>
+									</tbody>
+								</table>
+							</div>
+						</section>
+						<?php endif; ?>
+
+						<?php if (have_rows('college_rankings')): ?>
+						<section id="college-rankings" class="college-section">
+							<h2><?php esc_html_e('Rankings', 'collegenexis-theme'); ?></h2>
+							<ul>
+							<?php while(have_rows('college_rankings')): the_row(); ?>
+								<li>
+									<strong><?php echo esc_html(get_sub_field('rank_provider')); ?> (<?php echo esc_html(get_sub_field('rank_year')); ?>):</strong>
+									<?php echo esc_html(get_sub_field('rank_value')); ?>
+									<?php if ($stream = get_sub_field('rank_stream')): ?>
+										<em>for <?php echo esc_html($stream); ?></em>
+									<?php endif; ?>
+								</li>
+							<?php endwhile; ?>
+							</ul>
+						</section>
+						<?php endif; ?>
+
+						<?php if (get_field('college_placement_overview') || have_rows('college_placement_stats_repeater') || get_field('college_top_recruiters') ): ?>
+						<section id="college-placements" class="college-section">
+							<h2><?php esc_html_e('Placements', 'collegenexis-theme'); ?></h2>
+							<?php if ($placement_overview = get_field('college_placement_overview')): ?>
+								<div class="placement-overview"><?php echo wp_kses_post($placement_overview); ?></div>
+							<?php endif; ?>
+							<?php if (have_rows('college_placement_stats_repeater')): ?>
+								<h3><?php esc_html_e('Key Placement Statistics:', 'collegenexis-theme'); ?></h3>
+								<ul>
+								<?php while(have_rows('college_placement_stats_repeater')): the_row(); ?>
+									<li><strong><?php echo esc_html(get_sub_field('stat_label')); ?>:</strong> <?php echo esc_html(get_sub_field('stat_value')); ?></li>
+								<?php endwhile; ?>
+								</ul>
+							<?php endif; ?>
+							<?php if ($top_recruiters = get_field('college_top_recruiters')): ?>
+								<h3><?php esc_html_e('Top Recruiters:', 'collegenexis-theme'); ?></h3>
+								<p><?php echo nl2br(esc_html($top_recruiters)); ?></p>
+							<?php endif; ?>
+						</section>
+						<?php endif; ?>
+
+						<?php if ($scholarships = get_field('college_scholarships')): ?>
+						<section id="college-scholarships" class="college-section">
+							<h2><?php esc_html_e('Scholarships', 'collegenexis-theme'); ?></h2>
+							<?php echo wp_kses_post($scholarships); ?>
+						</section>
+						<?php endif; ?>
+
+						<section id="college-media" class="college-section">
+							<h2><?php esc_html_e('Media & Downloads', 'collegenexis-theme'); ?></h2>
+							<?php if ($brochure = get_field('college_brochure_file')): ?>
+								<p><a href="<?php echo esc_url($brochure['url']); ?>" target="_blank" class="button download-brochure"><?php esc_html_e('Download Brochure', 'collegenexis-theme'); ?></a> (<?php echo esc_html(strtoupper($brochure['subtype'])); ?>, <?php echo esc_html(size_format($brochure['filesize'])); ?>)</p>
+							<?php endif; ?>
+
+							<?php
+							$gallery_images = get_field('college_campus_gallery');
+							if ($gallery_images): ?>
+								<h3><?php esc_html_e('Campus Gallery', 'collegenexis-theme'); ?></h3>
+								<div class="college-gallery">
+									<?php foreach ($gallery_images as $image): ?>
+										<a href="<?php echo esc_url($image['url']); ?>" data-lightbox="college-gallery" data-title="<?php echo esc_attr($image['caption']); ?>">
+											<img src="<?php echo esc_url($image['sizes']['medium']); ?>" alt="<?php echo esc_attr($image['alt']); ?>" />
+										</a>
+									<?php endforeach; ?>
+								</div>
+                                <p><small><?php esc_html_e('(Gallery functionality may require a lightbox plugin for optimal viewing)', 'collegenexis-theme'); ?></small></p>
+							<?php endif; ?>
+						</section>
+
+					</div><!-- .entry-content -->
+
+					<footer class="entry-footer">
+						<?php edit_post_link(esc_html__('Edit This College', 'collegenexis-theme'), '<span class="edit-link">', '</span>'); ?>
+					</footer><!-- .entry-footer -->
+				</article><!-- #post-<?php the_ID(); ?> -->
+
+				<?php
+				// If comments are open or we have at least one comment, load up the comment template.
+				if ( comments_open() || get_comments_number() ) :
+					comments_template();
+				endif;
+
+				the_post_navigation(
+					array(
+						'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous College:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+						'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next College:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+					)
+				);
+
+			endwhile; // End of the loop.
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/single-course.php
+++ b/wp-content/themes/collegenexis-theme/single-course.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * The template for displaying all single Course posts
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php
+			while ( have_posts() ) :
+				the_post();
+
+				the_post();
+				?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class('course-profile'); ?>>
+					<header class="entry-header course-header">
+						<?php
+						$course_icon = get_field('course_icon');
+						if ($course_icon && isset($course_icon['url'])): ?>
+							<div class="course-icon">
+								<img src="<?php echo esc_url($course_icon['url']); ?>" alt="<?php echo esc_attr($course_icon['alt'] ?: get_the_title() . ' Icon'); ?>">
+							</div>
+						<?php endif; ?>
+						<?php the_title('<h1 class="entry-title course-name">', '</h1>'); ?>
+
+						<?php if ($summary = get_field('course_summary_short')): ?>
+							<p class="course-summary-tagline"><?php echo esc_html($summary); ?></p>
+						<?php endif; ?>
+					</header><!-- .entry-header -->
+
+					<div class="entry-content course-details-content">
+
+						<?php // Main Post Content (Detailed Description)
+                        if (get_the_content()): ?>
+                        <section id="course-detailed-description" class="course-section">
+                            <h2><?php esc_html_e('About This Course', 'collegenexis-theme'); ?></h2>
+                            <?php the_content(); ?>
+                        </section>
+                        <?php endif; ?>
+
+						<section id="course-overview" class="course-section">
+							<h2><?php esc_html_e('Course Overview', 'collegenexis-theme'); ?></h2>
+							<ul class="overview-details">
+								<?php if ($course_cat_terms = get_the_terms(get_the_ID(), 'course_category')): ?>
+									<li><strong><?php esc_html_e('Category:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($course_cat_terms[0]->name); ?></li>
+								<?php endif; ?>
+								<?php if ($duration = get_field('course_duration_details')): ?>
+									<li><strong><?php esc_html_e('Duration:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($duration); ?></li>
+								<?php endif; ?>
+							</ul>
+						</section>
+
+						<?php if ($eligibility = get_field('course_eligibility_criteria')): ?>
+						<section id="course-eligibility" class="course-section">
+							<h2><?php esc_html_e('Eligibility Criteria', 'collegenexis-theme'); ?></h2>
+							<?php echo wp_kses_post($eligibility); ?>
+						</section>
+						<?php endif; ?>
+
+						<?php if ($general_fees = get_field('course_general_fee_details')): ?>
+						<section id="course-general-fees" class="course-section">
+							<h2><?php esc_html_e('General Fee Information', 'collegenexis-theme'); ?></h2>
+							<?php echo wp_kses_post($general_fees); ?>
+						</section>
+						<?php endif; ?>
+
+						<section id="course-career-scope" class="course-section">
+							<h2><?php esc_html_e('Career Scope & Prospects', 'collegenexis-theme'); ?></h2>
+							<?php if ($career_scope_desc = get_field('course_career_scope_description')): ?>
+								<?php echo wp_kses_post($career_scope_desc); ?>
+							<?php endif; ?>
+							<?php if ($avg_salary = get_field('course_average_salary_general')): ?>
+								<p><strong><?php esc_html_e('Average Starting Salary (Estimate):', 'collegenexis-theme'); ?></strong> <?php echo esc_html($avg_salary); ?></p>
+							<?php endif; ?>
+							<?php if ($future_studies = get_field('course_future_studies_options')): ?>
+								<h3><?php esc_html_e('Future Studies Options:', 'collegenexis-theme'); ?></h3>
+								<?php echo wp_kses_post($future_studies); ?>
+							<?php endif; ?>
+						</section>
+
+						<?php if ($entrance_summary = get_field('course_entrance_exams_summary')): ?>
+						<section id="course-entrance-exams" class="course-section">
+							<h2><?php esc_html_e('Entrance Exams & Admission', 'collegenexis-theme'); ?></h2>
+							<?php echo wp_kses_post($entrance_summary); ?>
+						</section>
+						<?php endif; ?>
+
+						<?php
+						$colleges_offering = get_field('course_colleges_offering_this');
+						if ($colleges_offering): ?>
+						<section id="course-colleges-offering" class="course-section">
+							<h2><?php esc_html_e('Colleges Offering This Course (Examples)', 'collegenexis-theme'); ?></h2>
+							<ul class="colleges-list">
+								<?php foreach ($colleges_offering as $college_post): ?>
+									<li>
+										<a href="<?php echo esc_url(get_permalink($college_post->ID)); ?>">
+											<?php echo esc_html(get_the_title($college_post->ID)); ?>
+										</a>
+										<?php
+										$college_city = get_field('college_city', $college_post->ID);
+										if ($college_city) {
+											echo ' <span class="college-location">(' . esc_html($college_city) . ')</span>';
+										}
+										?>
+									</li>
+								<?php endforeach; ?>
+							</ul>
+							<p><small><?php esc_html_e('Note: For specific fee structures at each college, please refer to the individual college pages.', 'collegenexis-theme'); ?></small></p>
+						</section>
+						<?php endif; ?>
+
+					</div><!-- .entry-content -->
+
+					<footer class="entry-footer">
+						<?php edit_post_link(esc_html__('Edit This Course', 'collegenexis-theme'), '<span class="edit-link">', '</span>'); ?>
+					</footer><!-- .entry-footer -->
+				</article><!-- #post-<?php the_ID(); ?> -->
+				<?php
+
+				// If comments are open or we have at least one comment, load up the comment template.
+				if ( comments_open() || get_comments_number() ) :
+					comments_template();
+				endif;
+
+				the_post_navigation(
+					array(
+						'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous Course:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+						'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next Course:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+					)
+				);
+
+			endwhile; // End of the loop.
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/single-exam_update.php
+++ b/wp-content/themes/collegenexis-theme/single-exam_update.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * The template for displaying all single Exam Update posts
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php
+			while ( have_posts() ) :
+				the_post();
+
+				the_post();
+				?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class('exam-update-profile'); ?>>
+					<header class="entry-header exam-update-header">
+						<?php the_title('<h1 class="entry-title exam-update-name">', '</h1>'); ?>
+
+						<div class="exam-update-meta">
+							<?php if ($key_date = get_field('exam_update_date')): ?>
+								<span class="key-date"><strong><?php esc_html_e('Key Date:', 'collegenexis-theme'); ?></strong> <?php echo esc_html(date_i18n(get_option('date_format'), strtotime($key_date))); ?></span>
+							<?php endif; ?>
+							<?php
+							$update_type_value = get_field('exam_update_type');
+							$update_type_label = '';
+							$field_object = get_field_object('field_exam_update_type'); // Get field object to access choices
+							if ($field_object && isset($field_object['choices'][$update_type_value])) {
+								$update_type_label = $field_object['choices'][$update_type_value];
+							}
+							?>
+							<?php if ($update_type_label): ?>
+								<span class="update-type"><strong><?php esc_html_e('Update Type:', 'collegenexis-theme'); ?></strong> <?php echo esc_html($update_type_label); ?></span>
+							<?php endif; ?>
+						</div>
+					</header><!-- .entry-header -->
+
+					<div class="entry-content exam-update-details-content">
+
+						<?php if ($summary = get_field('exam_update_summary')): ?>
+						<section id="exam-update-summary-details" class="exam-update-section">
+							<h2><?php esc_html_e('Summary of Update', 'collegenexis-theme'); ?></h2>
+							<?php echo wp_kses_post($summary); ?>
+						</section>
+						<?php endif; ?>
+
+                        <?php // Main Post Content (Detailed Description if any)
+                        if (get_the_content()): ?>
+                        <section id="exam-update-detailed-info" class="exam-update-section">
+                            <h2><?php esc_html_e('Detailed Information', 'collegenexis-theme'); ?></h2>
+                            <?php the_content(); ?>
+                        </section>
+                        <?php endif; ?>
+
+						<?php if ($official_link = get_field('exam_update_official_link')): ?>
+						<section id="exam-update-official-link" class="exam-update-section">
+							<p>
+                                <strong><?php esc_html_e('Official Link:', 'collegenexis-theme'); ?></strong>
+                                <a href="<?php echo esc_url($official_link); ?>" target="_blank" rel="noopener noreferrer"><?php echo esc_html($official_link); ?></a>
+                            </p>
+						</section>
+						<?php endif; ?>
+
+						<?php
+						$related_courses = get_field('exam_update_related_course');
+						if ($related_courses): ?>
+						<section id="exam-update-related-courses" class="exam-update-section">
+							<h2><?php esc_html_e('Related Course(s)', 'collegenexis-theme'); ?></h2>
+							<ul>
+								<?php foreach ($related_courses as $course_post): ?>
+									<li><a href="<?php echo esc_url(get_permalink($course_post->ID)); ?>"><?php echo esc_html(get_the_title($course_post->ID)); ?></a></li>
+								<?php endforeach; ?>
+							</ul>
+						</section>
+						<?php endif; ?>
+
+					</div><!-- .entry-content -->
+
+					<footer class="entry-footer">
+						<?php edit_post_link(esc_html__('Edit This Update', 'collegenexis-theme'), '<span class="edit-link">', '</span>'); ?>
+					</footer><!-- .entry-footer -->
+				</article><!-- #post-<?php the_ID(); ?> -->
+				<?php
+
+				// Exam updates might not need comments, but the option is here
+				if ( comments_open() || get_comments_number() ) :
+					comments_template();
+				endif;
+
+				the_post_navigation(
+					array(
+						'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous Update:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+						'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next Update:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+					)
+				);
+
+			endwhile; // End of the loop.
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/single-roadmap.php
+++ b/wp-content/themes/collegenexis-theme/single-roadmap.php
@@ -1,0 +1,134 @@
+<?php
+/**
+ * The template for displaying all single Roadmap posts
+ *
+ * @package College_Nexis_Theme
+ */
+
+get_header();
+?>
+
+	<main id="primary" class="site-main">
+		<div class="container">
+			<?php
+			while ( have_posts() ) :
+				the_post();
+
+				the_post();
+				?>
+				<article id="post-<?php the_ID(); ?>" <?php post_class('roadmap-profile'); ?>>
+					<header class="entry-header roadmap-header">
+						<?php the_title('<h1 class="entry-title roadmap-name">', '</h1>'); ?>
+						<?php if ($introduction = get_field('roadmap_introduction')): ?>
+							<div class="roadmap-introduction lead">
+								<?php echo wp_kses_post($introduction); ?>
+							</div>
+						<?php endif; ?>
+					</header><!-- .entry-header -->
+
+					<div class="entry-content roadmap-details-content">
+						<?php if (have_rows('roadmap_steps')): ?>
+							<section id="roadmap-steps" class="roadmap-section">
+								<h2><?php esc_html_e('Career Steps', 'collegenexis-theme'); ?></h2>
+								<div class="steps-accordion">
+									<?php $step_count = 1; ?>
+									<?php while(have_rows('roadmap_steps')): the_row(); ?>
+										<div class="step-item">
+											<h3 class="step-title">
+												<button aria-expanded="false" aria-controls="step-content-<?php echo $step_count; ?>">
+													<span class="step-number"><?php esc_html_e('Step', 'collegenexis-theme'); ?> <?php echo $step_count; ?>:</span> <?php echo esc_html(get_sub_field('step_title')); ?>
+													<span class="icon" aria-hidden="true"></span>
+												</button>
+											</h3>
+											<div id="step-content-<?php echo $step_count; ?>" class="step-content" hidden>
+												<?php if ($step_description = get_sub_field('step_description')): ?>
+													<div class="step-description-content">
+														<?php echo wp_kses_post($step_description); ?>
+													</div>
+												<?php endif; ?>
+
+												<?php if ($step_courses = get_sub_field('step_courses')): ?>
+													<h4><?php esc_html_e('Recommended Courses:', 'collegenexis-theme'); ?></h4>
+													<ul>
+														<?php foreach($step_courses as $course_post): ?>
+															<li><a href="<?php echo esc_url(get_permalink($course_post->ID)); ?>"><?php echo esc_html(get_the_title($course_post->ID)); ?></a></li>
+														<?php endforeach; ?>
+													</ul>
+												<?php endif; ?>
+
+												<?php if ($step_colleges = get_sub_field('step_colleges')): ?>
+													<h4><?php esc_html_e('Suggested Colleges:', 'collegenexis-theme'); ?></h4>
+													<ul>
+														<?php foreach($step_colleges as $college_post): ?>
+															<li><a href="<?php echo esc_url(get_permalink($college_post->ID)); ?>"><?php echo esc_html(get_the_title($college_post->ID)); ?></a></li>
+														<?php endforeach; ?>
+													</ul>
+												<?php endif; ?>
+
+												<?php if ($step_skills = get_sub_field('step_skills')): ?>
+													<h4><?php esc_html_e('Skills to Acquire:', 'collegenexis-theme'); ?></h4>
+													<p><?php echo nl2br(esc_html($step_skills)); ?></p>
+												<?php endif; ?>
+											</div>
+										</div>
+										<?php $step_count++; ?>
+									<?php endwhile; ?>
+								</div>
+							</section>
+						<?php endif; ?>
+
+						<?php
+						$alt_paths = get_field('roadmap_alternative_paths');
+						$related_courses_general = get_field('roadmap_related_courses');
+						if ($alt_paths || $related_courses_general):
+						?>
+						<section id="roadmap-related-info" class="roadmap-section">
+							<h2><?php esc_html_e('Related Information', 'collegenexis-theme'); ?></h2>
+							<?php if ($alt_paths): ?>
+								<h3><?php esc_html_e('Alternative Career Paths:', 'collegenexis-theme'); ?></h3>
+								<ul>
+									<?php foreach($alt_paths as $path_post): ?>
+										<li><a href="<?php echo esc_url(get_permalink($path_post->ID)); ?>"><?php echo esc_html(get_the_title($path_post->ID)); ?></a></li>
+									<?php endforeach; ?>
+								</ul>
+							<?php endif; ?>
+							<?php if ($related_courses_general): ?>
+								<h3><?php esc_html_e('General Related Courses:', 'collegenexis-theme'); ?></h3>
+								<ul>
+									<?php foreach($related_courses_general as $course_post): ?>
+										<li><a href="<?php echo esc_url(get_permalink($course_post->ID)); ?>"><?php echo esc_html(get_the_title($course_post->ID)); ?></a></li>
+									<?php endforeach; ?>
+								</ul>
+							<?php endif; ?>
+						</section>
+						<?php endif; ?>
+
+                        <?php the_content(); // For any additional content added in main editor ?>
+
+					</div><!-- .entry-content -->
+
+					<footer class="entry-footer">
+						<?php edit_post_link(esc_html__('Edit This Roadmap', 'collegenexis-theme'), '<span class="edit-link">', '</span>'); ?>
+					</footer><!-- .entry-footer -->
+				</article><!-- #post-<?php the_ID(); ?> -->
+				<?php
+
+				// If comments are open or we have at least one comment, load up the comment template.
+				if ( comments_open() || get_comments_number() ) :
+					comments_template();
+				endif;
+
+				the_post_navigation(
+					array(
+						'prev_text' => '<span class="nav-subtitle">' . esc_html__( 'Previous Roadmap:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+						'next_text' => '<span class="nav-subtitle">' . esc_html__( 'Next Roadmap:', 'collegenexis-theme' ) . '</span> <span class="nav-title">%title</span>',
+					)
+				);
+
+			endwhile; // End of the loop.
+			?>
+		</div><!-- .container -->
+	</main><!-- #main -->
+
+<?php
+get_footer();

--- a/wp-content/themes/collegenexis-theme/style.css
+++ b/wp-content/themes/collegenexis-theme/style.css
@@ -1,0 +1,216 @@
+/*
+Theme Name: College Nexis Theme
+Theme URI: https://collegenexis.com/
+Author: Manas Ranjan Bisi
+Author URI: https://collegenexis.com/
+Description: A custom theme for College Nexis, designed to be a comprehensive career and college guide.
+Version: 1.0.0
+License: GNU General Public License v2 or later
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+Tags: education, college, career, custom-logo, custom-menu, featured-images, theme-options
+Text Domain: collegenexis-theme
+
+This theme, like WordPress, is licensed under the GPL.
+Use it to make something cool, have fun, and share what you've learned with others.
+*/
+
+/* Basic Reset */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body {
+    font-family: sans-serif; /* Placeholder, will be configurable */
+    line-height: 1.6;
+    color: #333; /* Placeholder */
+    background-color: #fff; /* Placeholder */
+}
+
+a {
+    color: #007bff; /* Placeholder primary color */
+    text-decoration: none;
+}
+
+a:hover {
+    text-decoration: underline;
+}
+
+img {
+    max-width: 100%;
+    height: auto;
+}
+
+/* Utility Classes */
+.container {
+    width: 90%;
+    max-width: 1100px;
+    margin: 0 auto;
+    padding: 20px 0;
+}
+
+/* Header Styling Placeholder */
+.site-header {
+    background-color: #f8f9fa; /* Placeholder */
+    padding: 1rem 0;
+    border-bottom: 1px solid #e7e7e7;
+}
+
+.site-header .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.site-branding .site-title a {
+    font-size: 1.8rem;
+    font-weight: bold;
+    color: #333;
+}
+.site-branding .site-description {
+    font-size: 0.9rem;
+    color: #777;
+}
+
+/* Navigation Placeholder */
+.main-navigation ul {
+    list-style: none;
+    display: flex;
+}
+
+.main-navigation ul li {
+    margin-left: 20px;
+}
+
+.main-navigation ul li a {
+    font-size: 1rem;
+}
+
+/* Main Content Area Placeholder */
+.site-content {
+    padding: 20px 0;
+}
+
+/* Footer Styling Placeholder */
+.site-footer {
+    background-color: #343a40; /* Placeholder */
+    color: #fff;
+    padding: 2rem 0;
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+/* WordPress Core CSS Classes */
+.alignnone {
+    margin: 5px 20px 20px 0;
+}
+
+.aligncenter,
+div.aligncenter {
+    display: block;
+    margin: 5px auto 5px auto;
+}
+
+.alignright {
+    float: right;
+    margin: 5px 0 20px 20px;
+}
+
+.alignleft {
+    float: left;
+    margin: 5px 20px 20px 0;
+}
+
+a img.alignright {
+    float: right;
+    margin: 5px 0 20px 20px;
+}
+
+a img.alignnone {
+    margin: 5px 20px 20px 0;
+}
+
+a img.alignleft {
+    float: left;
+    margin: 5px 20px 20px 0;
+}
+
+a img.aligncenter {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+}
+
+.wp-caption {
+    background: #fff;
+    border: 1px solid #f0f0f0;
+    max-width: 96%; /* Image does not overflow the content area */
+    padding: 5px 3px 10px;
+    text-align: center;
+}
+
+.wp-caption.alignnone {
+    margin: 5px 20px 20px 0;
+}
+
+.wp-caption.alignleft {
+    margin: 5px 20px 20px 0;
+}
+
+.wp-caption.alignright {
+    margin: 5px 0 20px 20px;
+}
+
+.wp-caption img {
+    border: 0 none;
+    height: auto;
+    margin: 0;
+    max-width: 98.5%;
+    padding: 0;
+    width: auto;
+}
+
+.wp-caption p.wp-caption-text {
+    font-size: 11px;
+    line-height: 17px;
+    margin: 0;
+    padding: 0 4px 5px;
+}
+
+/* Screen Reader Text */
+.screen-reader-text {
+	border: 0;
+	clip: rect(1px, 1px, 1px, 1px);
+	clip-path: inset(50%);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute !important;
+	width: 1px;
+	word-wrap: normal !important; /* Many screen reader and browser combinations announce broken words as they would appear visually. */
+}
+
+.screen-reader-text:focus {
+	background-color: #f1f1f1;
+	border-radius: 3px;
+	box-shadow: 0 0 2px 2px rgba(0, 0, 0, 0.6);
+	clip: auto !important;
+	clip-path: none;
+	color: #21759b;
+	display: block;
+	font-size: 14px;
+	font-size: 0.875rem;
+	font-weight: bold;
+	height: auto;
+	left: 5px;
+	line-height: normal;
+	padding: 15px 23px 14px;
+	text-decoration: none;
+	top: 5px;
+	width: auto;
+	z-index: 100000; /* Above WP toolbar. */
+}
+
+/* More specific styles will be added as we develop components */

--- a/wp-content/themes/collegenexis-theme/template-parts/content-none.php
+++ b/wp-content/themes/collegenexis-theme/template-parts/content-none.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Template part for displaying a message that posts cannot be found
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package College_Nexis_Theme
+ */
+
+?>
+
+<section class="no-results not-found">
+	<header class="page-header">
+		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'collegenexis-theme' ); ?></h1>
+	</header><!-- .page-header -->
+
+	<div class="page-content">
+		<?php
+		if ( is_home() && current_user_can( 'publish_posts' ) ) :
+
+			printf(
+				'<p>' . wp_kses(
+					/* translators: 1: link to WP admin new post page. */
+					__( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'collegenexis-theme' ),
+					array(
+						'a' => array(
+							'href' => array(),
+						),
+					)
+				) . '</p>',
+				esc_url( admin_url( 'post-new.php' ) )
+			);
+
+		elseif ( is_search() ) :
+			?>
+
+			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'collegenexis-theme' ); ?></p>
+			<?php
+			get_search_form();
+
+		else :
+			?>
+
+			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'collegenexis-theme' ); ?></p>
+			<?php
+			get_search_form();
+
+		endif;
+		?>
+	</div><!-- .page-content -->
+</section><!-- .no-results -->

--- a/wp-content/themes/collegenexis-theme/template-parts/content.php
+++ b/wp-content/themes/collegenexis-theme/template-parts/content.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Template part for displaying posts
+ *
+ * @link https://developer.wordpress.org/themes/basics/template-hierarchy/
+ *
+ * @package College_Nexis_Theme
+ */
+
+?>
+
+<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
+	<header class="entry-header">
+		<?php
+		if ( is_singular() ) :
+			the_title( '<h1 class="entry-title">', '</h1>' );
+		else :
+			the_title( '<h2 class="entry-title"><a href="' . esc_url( get_permalink() ) . '" rel="bookmark">', '</a></h2>' );
+		endif;
+
+		if ( 'post' === get_post_type() ) :
+			?>
+			<div class="entry-meta">
+				<?php
+				collegenexis_theme_posted_on();
+				collegenexis_theme_posted_by();
+				?>
+			</div><!-- .entry-meta -->
+		<?php endif; ?>
+	</header><!-- .entry-header -->
+
+	<?php collegenexis_theme_post_thumbnail(); // Function to display post thumbnail (to be created in template-tags.php) ?>
+
+	<div class="entry-content">
+		<?php
+		the_content(
+			sprintf(
+				wp_kses(
+					/* translators: %s: Name of current post. Only visible to screen readers */
+					__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'collegenexis-theme' ),
+					array(
+						'span' => array(
+							'class' => array(),
+						),
+					)
+				),
+				get_the_title()
+			)
+		);
+
+		wp_link_pages(
+			array(
+				'before' => '<div class="page-links">' . esc_html__( 'Pages:', 'collegenexis-theme' ),
+				'after'  => '</div>',
+			)
+		);
+		?>
+	</div><!-- .entry-content -->
+
+	<footer class="entry-footer">
+		<?php collegenexis_theme_entry_footer(); // Function for categories, tags, comments link (to be created in template-tags.php) ?>
+	</footer><!-- .entry-footer -->
+</article><!-- #post-<?php the_ID(); ?> -->


### PR DESCRIPTION
- Refined ACF field definitions for College and Course CPTs to align with College Dunia data structure, incorporating tabs and improved field organization for admin UI.
- Added 'Is Featured?' ACF field to Colleges for homepage display.
- Customized admin list columns for College and Course CPTs (added logo/icon, city, state, estd. year, duration, category) and made them sortable.
- Updated single and archive templates for all CPTs (College, Course, Roadmap, Exam Update) to display data from their respective ACF fields in a structured layout.
- Created `front-page.php` with sections for Hero (w/ search), Featured Colleges (querying 'Is Featured?' field), Browse by Course Category, Latest Blog Posts, and Latest Exam Updates.
- Provided guidance on CSV header structure for data import.

This commit focuses on preparing the backend for detailed data and implementing the initial front-end display of this data.