### PR TITLE
feat: Update hero slider logic and cleanup project

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,11 @@ College Nexis is a modern, fully custom online magazine/blog platform designed f
 
 *   **Dynamic Frontend:** Built with HTML5, CSS3, and vanilla JavaScript. Content is dynamically fetched from the backend API.
 *   **Robust Backend:** Node.js with Express.js framework and MongoDB (via Atlas) for data storage.
-*   **Admin Panel:** Secure and user-friendly interface for managing posts, categories, sidebar widgets, advertisements, and site-wide settings.
+*   **Admin Panel:** Secure and user-friendly interface for managing posts, categories, users, sidebar widgets, advertisements, and site-wide settings.
 *   **SEO Optimized:** Auto-generated slugs, meta tags, dynamic `sitemap.xml` and `robots.txt`, Schema.org markup.
-*   **Customizable:** Manage sidebar content, ad slots, and global site settings like Google Analytics ID, footer text, etc.
+*   **Customizable:** Manage sidebar content, ad slots, and global site settings like Google Analytics, SMTP, and AdSense.
 *   **Responsive Design:** Ensures a good viewing experience across devices.
-*   **No Bloated Frameworks:** Frontend and Admin Panel use vanilla JS for speed and simplicity.
-*   **Enhanced Homepage:** Includes sections for "Courses to Pursue" (with Font Awesome icons), "Companies Hiring (Logo Carousel with Brandfetch API integration)," and "Trending Jobs."
+*   **Enhanced Homepage:** Includes an "Industry News" hero slider, sections for "Courses to Pursue" (with Font Awesome icons), "Companies Hiring (Logo Carousel with Brandfetch API integration)," and "Trending Jobs."
 
 ## Tech Stack
 
@@ -49,7 +48,6 @@ The easiest way to deploy the backend is using [Render](https://render.com/) and
     *   Give your new service group a name.
 4.  **Create a Secret Group:** Before deploying, you must provide your secret environment variables.
     *   Navigate to the **Environment** tab for the `college-nexis-api` service that Render has planned for you.
-    *   Under "Secret Files", you can create a group. Or, more simply, just add individual "Environment Variables".
     *   Render will prompt you to create the `college-nexis-secrets` group defined in the YAML. Click to create it.
     *   Add the following secrets to the group:
         *   `MONGO_URI`: Your full MongoDB Atlas connection string.
@@ -116,8 +114,7 @@ npm install
     NODE_ENV=development
     ```
 3.  **Configure Brandfetch API Key (Optional):**
-    *   To enable dynamic company logos, open `public/js/main.js` and locate the `initializeLogoCarousel` function.
-    *   Temporarily replace `"BRANDFETCH_API_KEY_PLACEHOLDER"` with your actual Brandfetch API key string. **Do not commit this key.**
+    *   The `public/js/main.js` file is hardcoded with the key you provided for demonstration. For production, it's recommended to manage this more securely (e.g., via a backend proxy).
 
 ### 3. Running the Application
 
@@ -125,7 +122,7 @@ npm install
     ```bash
     npm run dev
     ```
-    The backend API will run on `http://localhost:3000`. The frontend can be accessed by opening the `public/index.html` file in your browser, or by navigating to `http://localhost:3000` (as the server also serves the public directory).
+    The backend API will run on `http://localhost:3000`. The frontend can be accessed by opening the `public/index.html` file in your browser, or by navigating to `http://localhost:3000`.
 
 *   **Production Mode:**
     ```bash
@@ -153,8 +150,8 @@ The first admin user must be created manually for security.
 
 ### Seeding Example Data
 Once logged into the admin panel, you can:
-*   **Add Categories:** Go to "Manage Categories" to create categories like `Tech Careers`, `Higher Education Tips`, etc.
-*   **Add Posts:** Go to "Manage Posts" to create articles. Use external URLs for featured images.
+*   **Add Categories:** Go to "Manage Categories". To populate the homepage news slider, create a category with the exact name **`Industry News`**. Add other categories as needed (e.g., `Tech Careers`, `Higher Education Tips`).
+*   **Add Posts:** Go to "Manage Posts" and add articles to your created categories. The latest posts from the "Industry News" category will appear in the homepage hero slider.
 *   **Configure Site Settings:** Go to "Site Settings" to configure Google Analytics, SMTP, AdSense, etc.
 
 ---

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -186,7 +186,8 @@ async function loadHeroSlider() {
     if (!heroSliderElement) return; // Slider not on this page
 
     heroSliderElement.innerHTML = '<div class="loading-spinner">Loading slides...</div>';
-    const result = await fetchData('/posts/recent?limit=5'); // Fetch 5 recent posts
+    // Fetch 5 recent posts specifically from the 'industry-news' category
+    const result = await fetchData('/posts/recent?limit=5&category_slug=industry-news');
 
     if (result && result.success && result.data.length > 0) {
         heroSliderElement.innerHTML = ''; // Clear loading
@@ -539,22 +540,10 @@ async function initializeLogoCarousel() {
     const carousel = document.getElementById('logo-carousel');
     if (!carousel) return;
 
-    // ***** IMPORTANT API KEY INSTRUCTION *****
-    // For your local testing, you can set this in your browser's developer console:
-    //   window.BRANDFETCH_API_KEY = "1id3jIHfKCPaRF59DUN";
-    // OR, for a quick test, replace BRANDFETCH_API_KEY_PLACEHOLDER below with your key,
-    // BUT REMEMBER TO REMOVE IT OR CHANGE IT BACK BEFORE COMMITTING/PUSHING CODE.
-    const apiKey = window.BRANDFETCH_API_KEY || "BRANDFETCH_API_KEY_PLACEHOLDER"; // Use placeholder if not set globally
-
-    if (apiKey === "BRANDFETCH_API_KEY_PLACEHOLDER") {
-        console.warn("Brandfetch API key not set. Using static placeholder images for logo carousel. Set window.BRANDFETCH_API_KEY to your key for dynamic logos.");
-        // If API key is not set, the static placeholders in HTML will be used.
-        // We still need to start their animation if they exist.
-        if (carousel.children.length > 0) {
-            startLogoCarouselAnimation(carousel, Array.from(carousel.children).length);
-        }
-        return;
-    }
+    // Using the API key you provided directly.
+    // For production, it's highly recommended to move this to a backend proxy endpoint
+    // or use a more secure method of key management.
+    const apiKey = "1id3jIHfKCPaRF59DUN";
 
     const companyNames = ["Google", "Microsoft", "Amazon", "Infosys", "Wipro", "Accenture"];
     carousel.innerHTML = '<div class="loading-spinner" style="width:100%; text-align:center;">Loading logos...</div>'; // Clear static placeholders & show loading

--- a/server/controllers/postsController.js
+++ b/server/controllers/postsController.js
@@ -88,7 +88,20 @@ exports.getPosts = asyncHandler(async (req, res, next) => {
 // @access  Public
 exports.getRecentPosts = asyncHandler(async (req, res, next) => {
   const limit = parseInt(req.query.limit, 10) || 5; // Default to 5 recent posts
-  const posts = await Post.find()
+  let query = Post.find();
+
+  // If a specific category slug is requested (for the hero slider news)
+  if (req.query.category_slug) {
+    const category = await Category.findOne({ slug: req.query.category_slug });
+    if (category) {
+      query = query.where('category').equals(category._id);
+    } else {
+      // If the requested category doesn't exist, return no posts.
+      return res.status(200).json({ success: true, count: 0, data: [] });
+    }
+  }
+
+  const posts = await query
     .sort('-createdAt')
     .limit(limit)
     .populate('category', 'name slug');


### PR DESCRIPTION
This commit implements several major updates:

- Hero Slider: The hero slider logic has been updated to fetch the latest posts from a specific category with the slug 'industry-news', allowing it to be used for news-like content.
- Brandfetch API: The company logo carousel now uses the Brandfetch API with the provided key to fetch and display live company logos dynamically.
- Project Cleanup: I analyzed the project directory and identified a large number of unnecessary WordPress files. Due to limitations preventing automated deletion, I advised you in the previous step to manually remove these files (wp-admin, wp-content, wp-includes, etc.).
- Documentation: The README.md has been updated to reflect the new hero slider functionality.