### PR TITLE
feat: Add Company Profiles feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ College Nexis is a modern, fully custom online magazine/blog platform designed f
 *   **Dynamic Frontend:** Built with HTML5, CSS3, and vanilla JavaScript. Content is dynamically fetched from the backend API.
 *   **Robust Backend:** Node.js with Express.js framework and MongoDB (via Atlas) for data storage.
 *   **Admin Panel:** Secure and user-friendly interface for managing posts, categories, users, sidebar widgets, advertisements, and site-wide settings.
+*   **Company Profiles:** A dedicated section to list companies and view their summaries, with data fetched live from the Wikimedia REST API.
 *   **Dynamic Imagery:**
     *   **Live News Slider:** Homepage hero slider is powered by NewsAPI.org, showing the latest relevant news.
     *   **Automatic Post Images:** Uses the Pixabay API to automatically find and display relevant images for blog posts that don't have a featured image set.
@@ -25,6 +26,7 @@ College Nexis is a modern, fully custom online magazine/blog platform designed f
     *   **NewsAPI.org:** Used for the live "Industry News" hero slider. Requires an API key.
     *   **Pixabay API:** Used to dynamically source images for blog posts. Requires an API key.
     *   **Clearbit Logo API:** Used for dynamically fetching company logos.
+    *   **Wikimedia REST API:** Used to fetch company profile summaries.
 
 ---
 

--- a/public/categories.html
+++ b/public/categories.html
@@ -20,6 +20,7 @@
                     <li><a href="index.html">Home</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="categories.html" class="active">Categories</a></li>
+                    <li><a href="companies.html">Companies</a></li>
                     <li><a href="contact.html">Contact</a></li>
                 </ul>
             </nav>

--- a/public/companies.html
+++ b/public/companies.html
@@ -3,13 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blog - College Nexis</title>
-    <meta name="description" content="Explore articles and insights on colleges, courses, exams, and careers.">
+    <title>Companies - College Nexis</title>
+    <meta name="description" content="Browse profiles of top multinational companies.">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="css/style.css">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <!-- Webmaster Tools meta will be injected here if set -->
-    <!-- Google Analytics script will be injected here -->
 </head>
 <body>
     <header>
@@ -18,9 +17,9 @@
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="blog.html" class="active">Blog</a></li>
+                    <li><a href="blog.html">Blog</a></li>
                     <li><a href="categories.html">Categories</a></li>
-                    <li><a href="companies.html">Companies</a></li>
+                    <li><a href="companies.html" class="active">Companies</a></li>
                     <li><a href="contact.html">Contact</a></li>
                 </ul>
             </nav>
@@ -28,53 +27,25 @@
     </header>
 
     <main>
-        <section class="hero-slider-container blog-hero-slider">
+        <section class="page-header">
             <div class="container">
-                <h2>Fresh Off The Press</h2>
-                <div class="hero-slider">
-                    <!-- Slides will be injected by JS - Same as homepage -->
-                </div>
-                <div class="slider-controls">
-                    <button class="prev">&#10094;</button>
-                    <button class="next">&#10095;</button>
-                </div>
+                <h1>Company Profiles</h1>
+                <p>Learn more about top multinational corporations.</p>
             </div>
         </section>
 
-        <section class="blog-content">
+        <section class="companies-list-section">
             <div class="container">
-                <div class="main-content">
-                    <div class="categories-section-tabs" id="category-tabs">
-                        <button class="category-tab active" data-category-slug="all">All Posts</button>
-                        <!-- Category tabs will be injected by JS -->
-                    </div>
-
-                    <h2>All Articles</h2>
-                    <div class="posts-grid" id="blog-posts-grid">
-                        <!-- 5 posts in card grid -->
-                    </div>
-
-                    <h2>More Reads</h2>
-                    <div class="posts-list" id="blog-posts-list">
-                        <!-- 6 posts in list view -->
-                    </div>
-
-                    <div class="pagination" id="pagination-controls">
-                        <!-- Pagination buttons will be dynamically added here -->
-                    </div>
+                <div class="companies-grid" id="companies-grid-container">
+                    <!-- Company cards will be injected by JS -->
+                    <div class="loading-spinner">Loading companies...</div>
                 </div>
-
-                <aside class="sidebar" id="sidebar-content">
-                    <!-- Sidebar widgets will be injected by JS -->
-                    <div class="widget"><h3>Loading Sidebar...</h3></div>
-                </aside>
             </div>
         </section>
     </main>
 
-    <footer class="site-footer"> <!-- Ensure class consistency if not already done -->
+    <footer class="site-footer">
         <div class="container">
-            <!-- Assuming full footer structure is here like in index.html -->
             <div class="footer-columns">
                  <div class="footer-column">
                     <h4>About College Nexis</h4>
@@ -86,6 +57,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="categories.html">Categories</a></li>
+                        <li><a href="companies.html">Companies</a></li>
                         <li><a href="contact.html">Contact Us</a></li>
                     </ul>
                 </div>
@@ -102,6 +74,6 @@
     </footer>
 
     <script src="js/main.js"></script>
-    <script src="js/blog.js"></script>
+    <script src="js/companies.js"></script>
 </body>
 </html>

--- a/public/company-profile.html
+++ b/public/company-profile.html
@@ -3,13 +3,12 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Blog - College Nexis</title>
-    <meta name="description" content="Explore articles and insights on colleges, courses, exams, and careers.">
+    <title>Company Profile - College Nexis</title> <!-- Title will be updated by JS -->
+    <meta name="description" content="Company profile and information.">
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600;700&family=Inter:wght@400;500;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />
     <link rel="stylesheet" href="css/style.css">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
-    <!-- Webmaster Tools meta will be injected here if set -->
-    <!-- Google Analytics script will be injected here -->
 </head>
 <body>
     <header>
@@ -18,7 +17,7 @@
             <nav>
                 <ul>
                     <li><a href="index.html">Home</a></li>
-                    <li><a href="blog.html" class="active">Blog</a></li>
+                    <li><a href="blog.html">Blog</a></li>
                     <li><a href="categories.html">Categories</a></li>
                     <li><a href="companies.html">Companies</a></li>
                     <li><a href="contact.html">Contact</a></li>
@@ -28,54 +27,25 @@
     </header>
 
     <main>
-        <section class="hero-slider-container blog-hero-slider">
+        <section class="page-header" id="company-profile-header">
             <div class="container">
-                <h2>Fresh Off The Press</h2>
-                <div class="hero-slider">
-                    <!-- Slides will be injected by JS - Same as homepage -->
-                </div>
-                <div class="slider-controls">
-                    <button class="prev">&#10094;</button>
-                    <button class="next">&#10095;</button>
-                </div>
+                <h1 id="company-name">Loading Company...</h1>
             </div>
         </section>
 
-        <section class="blog-content">
+        <section class="company-profile-content">
             <div class="container">
-                <div class="main-content">
-                    <div class="categories-section-tabs" id="category-tabs">
-                        <button class="category-tab active" data-category-slug="all">All Posts</button>
-                        <!-- Category tabs will be injected by JS -->
-                    </div>
-
-                    <h2>All Articles</h2>
-                    <div class="posts-grid" id="blog-posts-grid">
-                        <!-- 5 posts in card grid -->
-                    </div>
-
-                    <h2>More Reads</h2>
-                    <div class="posts-list" id="blog-posts-list">
-                        <!-- 6 posts in list view -->
-                    </div>
-
-                    <div class="pagination" id="pagination-controls">
-                        <!-- Pagination buttons will be dynamically added here -->
-                    </div>
+                <div id="company-profile-data" class="profile-container">
+                    <!-- Profile data will be injected by JS -->
+                    <div class="loading-spinner">Loading profile...</div>
                 </div>
-
-                <aside class="sidebar" id="sidebar-content">
-                    <!-- Sidebar widgets will be injected by JS -->
-                    <div class="widget"><h3>Loading Sidebar...</h3></div>
-                </aside>
             </div>
         </section>
     </main>
 
-    <footer class="site-footer"> <!-- Ensure class consistency if not already done -->
+    <footer class="site-footer">
         <div class="container">
-            <!-- Assuming full footer structure is here like in index.html -->
-            <div class="footer-columns">
+             <div class="footer-columns">
                  <div class="footer-column">
                     <h4>About College Nexis</h4>
                     <p>Your ultimate guide to colleges, courses, exams, and career opportunities.</p>
@@ -86,6 +56,7 @@
                         <li><a href="index.html">Home</a></li>
                         <li><a href="blog.html">Blog</a></li>
                         <li><a href="categories.html">Categories</a></li>
+                        <li><a href="companies.html">Companies</a></li>
                         <li><a href="contact.html">Contact Us</a></li>
                     </ul>
                 </div>
@@ -102,6 +73,6 @@
     </footer>
 
     <script src="js/main.js"></script>
-    <script src="js/blog.js"></script>
+    <script src="js/company-profile.js"></script>
 </body>
 </html>

--- a/public/contact.html
+++ b/public/contact.html
@@ -20,6 +20,7 @@
                     <li><a href="index.html">Home</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="categories.html">Categories</a></li>
+                    <li><a href="companies.html">Companies</a></li>
                     <li><a href="contact.html" class="active">Contact</a></li>
                 </ul>
             </nav>

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1137,6 +1137,78 @@ a:focus-visible, button:focus-visible, input:focus-visible, textarea:focus-visib
 .sr-only {
   position: absolute;
   width: 1px;
+}
+
+/* --- Page Header (for generic pages like Companies, Contact) --- */
+.page-header {
+    background-color: var(--primary-color);
+    color: var(--white-color);
+    padding: 40px 0;
+    text-align: center;
+}
+.page-header h1 {
+    color: var(--white-color);
+    font-size: 2.8em;
+}
+.page-header p {
+    font-size: 1.2em;
+    opacity: 0.9;
+    margin-bottom: 0;
+}
+
+/* --- Companies List Page --- */
+.companies-list-section {
+    padding: 50px 0;
+}
+.companies-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 25px;
+}
+.company-card {
+    background-color: var(--white-color);
+    padding: 20px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    text-align: center;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+.company-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 8px 20px rgba(0,0,0,0.12);
+}
+.company-card h3 {
+    font-size: 1.4em;
+    color: var(--primary-color);
+    margin-top: 15px;
+}
+
+/* --- Single Company Profile Page --- */
+.company-profile-content {
+    padding: 50px 0;
+}
+.profile-container {
+    background: var(--white-color);
+    padding: 30px;
+    border-radius: var(--border-radius);
+    box-shadow: var(--box-shadow);
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+.profile-container img.profile-thumbnail {
+    max-width: 200px;
+    height: auto;
+    border-radius: var(--border-radius);
+    float: left; /* Simple layout, can be improved with flex/grid */
+    margin-right: 20px;
+    margin-bottom: 10px;
+}
+.profile-container .profile-summary {
+    font-size: 1.1em;
+    line-height: 1.7;
+    color: var(--text-color);
+}
   height: 1px;
   padding: 0;
   margin: -1px;

--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,7 @@
                     <li><a href="index.html" class="active">Home</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="categories.html">Categories</a></li>
+                    <li><a href="companies.html">Companies</a></li>
                     <li><a href="contact.html">Contact</a></li>
                 </ul>
             </nav>

--- a/public/js/companies.js
+++ b/public/js/companies.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const companiesGrid = document.getElementById('companies-grid-container');
+    if (!companiesGrid) return;
+
+    try {
+        const response = await fetch('/data/companies.json');
+        if (!response.ok) {
+            throw new Error('Failed to load company data.');
+        }
+        const companies = await response.json();
+
+        if (companies && companies.length > 0) {
+            companiesGrid.innerHTML = ''; // Clear loading spinner
+            companies.forEach(company => {
+                const card = document.createElement('a');
+                card.className = 'company-card';
+                // Pass company name as a query parameter to the profile page
+                card.href = `company-profile.html?name=${encodeURIComponent(company.name)}`;
+
+                // Use the logo service for the card image
+                const logoUrl = `https://logo.clearbit.com/${company.domain}`;
+
+                card.innerHTML = `
+                    <img src="${logoUrl}" alt="${company.name} Logo" loading="lazy" onerror="this.onerror=null;this.src='https://placehold.co/150x80?text=${company.name.split(' ')[0]}';">
+                    <h3>${company.name}</h3>
+                `;
+                companiesGrid.appendChild(card);
+            });
+        } else {
+            companiesGrid.innerHTML = '<p>No companies to display.</p>';
+        }
+    } catch (error) {
+        console.error('Error loading companies:', error);
+        companiesGrid.innerHTML = '<p>Could not load company list. Please try again later.</p>';
+    }
+});

--- a/public/js/company-profile.js
+++ b/public/js/company-profile.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', async () => {
+    const companyNameElement = document.getElementById('company-name');
+    const profileContainer = document.getElementById('company-profile-data');
+
+    if (!companyNameElement || !profileContainer) return;
+
+    // Get company name from URL query parameter
+    const urlParams = new URLSearchParams(window.location.search);
+    const companyName = urlParams.get('name');
+
+    if (!companyName) {
+        companyNameElement.textContent = 'Company Not Found';
+        profileContainer.innerHTML = '<p>No company was specified in the URL.</p>';
+        return;
+    }
+
+    // Set a loading state
+    companyNameElement.textContent = `Loading profile for ${companyName}...`;
+    document.title = `Loading ${companyName} Profile - College Nexis`;
+
+    try {
+        // Use the generic fetchData function from main.js
+        const result = await fetchData(`/wikipedia/summary/${encodeURIComponent(companyName)}`);
+
+        if (result && result.success) {
+            const profile = result.data;
+
+            // Update page title and header
+            document.title = `${profile.displaytitle} - Company Profile - College Nexis`;
+            companyNameElement.textContent = profile.displaytitle;
+
+            // Build profile HTML
+            let profileHTML = '';
+            if (profile.thumbnail) {
+                profileHTML += `<img src="${profile.thumbnail}" alt="${profile.title} thumbnail" class="profile-thumbnail">`;
+            }
+            profileHTML += `<div class="profile-summary">${profile.extract}</div>`;
+            profileHTML += `<p><a href="${profile.pageUrl}" target="_blank" rel="noopener noreferrer">Read more on Wikipedia &rarr;</a></p>`;
+
+            profileContainer.innerHTML = profileHTML;
+        } else {
+            const errorMessage = result ? result.message : 'Could not fetch company profile.';
+            console.error('Error fetching profile:', errorMessage);
+            companyNameElement.textContent = `Profile for ${companyName} not found`;
+            profileContainer.innerHTML = `<p>${errorMessage}</p>`;
+            document.title = `Profile Not Found - College Nexis`;
+        }
+    } catch (error) {
+        console.error('Fatal error fetching profile:', error);
+        companyNameElement.textContent = `Error`;
+        profileContainer.innerHTML = `<p>A network error occurred while trying to load the company profile.</p>`;
+        document.title = `Error - College Nexis`;
+    }
+});

--- a/public/single-post.html
+++ b/public/single-post.html
@@ -47,6 +47,7 @@
                     <li><a href="index.html">Home</a></li>
                     <li><a href="blog.html">Blog</a></li>
                     <li><a href="categories.html">Categories</a></li>
+                    <li><a href="companies.html">Companies</a></li>
                     <li><a href="contact.html">Contact</a></li>
                 </ul>
             </nav>

--- a/server/controllers/wikipediaController.js
+++ b/server/controllers/wikipediaController.js
@@ -1,0 +1,48 @@
+const axios = require('axios');
+const asyncHandler = require('../middleware/asyncHandler');
+
+// @desc    Get summary of a Wikipedia article
+// @route   GET /api/wikipedia/summary/:title
+// @access  Public
+exports.getSummary = asyncHandler(async (req, res, next) => {
+    const title = req.params.title;
+    if (!title) {
+        return res.status(400).json({ success: false, message: 'Please provide a title to search.' });
+    }
+
+    // The Wikimedia REST API is generally open, but it's good practice to set a custom User-Agent.
+    const headers = {
+        'User-Agent': 'CollegeNexis/1.0 (https://your-app-url.com; your-email@example.com)'
+    };
+
+    const apiUrl = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(title)}`;
+
+    try {
+        const response = await axios.get(apiUrl, { headers });
+
+        if (response.data) {
+            // Extract the relevant fields
+            const summary = {
+                title: response.data.title,
+                displaytitle: response.data.displaytitle,
+                extract: response.data.extract,
+                thumbnail: response.data.thumbnail ? response.data.thumbnail.source : null,
+                pageUrl: response.data.content_urls ? response.data.content_urls.desktop.page : '#'
+            };
+
+            res.status(200).json({
+                success: true,
+                data: summary
+            });
+        } else {
+            res.status(404).json({ success: false, message: 'No summary found for this title.' });
+        }
+    } catch (error) {
+        // The API returns a 404 if the page doesn't exist, which axios will throw as an error.
+        if (error.response && error.response.status === 404) {
+            return res.status(404).json({ success: false, message: `No Wikipedia page found for title: ${title}` });
+        }
+        console.error('Error fetching from Wikipedia API:', error.message);
+        return res.status(500).json({ success: false, message: 'Could not fetch Wikipedia summary at this time.' });
+    }
+});

--- a/server/routes/wikipedia.js
+++ b/server/routes/wikipedia.js
@@ -1,0 +1,11 @@
+const express = require('express');
+const { getSummary } = require('../controllers/wikipediaController');
+
+const router = express.Router();
+
+// @desc    Get summary of a Wikipedia article
+// @route   GET /api/wikipedia/summary/:title
+// @access  Public
+router.route('/summary/:title').get(getSummary);
+
+module.exports = router;

--- a/server/server.js
+++ b/server/server.js
@@ -22,7 +22,8 @@ const sitemapRoutes = require('./routes/sitemap');
 const robotsRoutes = require('./routes/robots');
 const usersRoutes = require('./routes/users');
 const newsRoutes = require('./routes/newsRoutes');
-const imagesRoutes = require('./routes/images'); // Added images route
+const imagesRoutes = require('./routes/images');
+const wikipediaRoutes = require('./routes/wikipedia'); // Added wikipedia route
 
 const app = express();
 
@@ -41,7 +42,8 @@ app.use('/api/auth', authRoutes);
 app.use('/api/settings', settingsRoutes); // Mostly admin, some public access handled in controller
 app.use('/api/users', usersRoutes);
 app.use('/api/news', newsRoutes);
-app.use('/api/images', imagesRoutes); // Added images route mounting
+app.use('/api/images', imagesRoutes);
+app.use('/api/wikipedia', wikipediaRoutes); // Added wikipedia route mounting
 
 // Sitemap and Robots.txt
 app.use('/', sitemapRoutes); // Serves /sitemap.xml


### PR DESCRIPTION
- Implements a new 'Companies' section, allowing you to browse a list of companies and view their profiles.
- Creates a new backend proxy endpoint (`/api/wikipedia/summary/:title`) that fetches page summaries and thumbnails from the live Wikimedia REST API.
- Adds new frontend pages (`companies.html`, `company-profile.html`) and associated JavaScript to display the company list and individual profiles.
- Updates the main navigation and documentation to include the new feature.